### PR TITLE
feat: native module front-controller API endpoints + Dockerized test harness

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+vendor2
+vendor
+run
+node_modules
+*.zip

--- a/.github/scripts/build-zip.sh
+++ b/.github/scripts/build-zip.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 tmpdir=$(mktemp -d)
-ignore=".git .github .idea .vscode .gitignore .php-cs-fixer.dist.php .php-cs-fixer.cache composer.* tests run doc vendor vendor2 docker-compose.yml docker-compose.test.yml Makefile *.zip"
+ignore=".git .github .idea .vscode .gitignore .php-cs-fixer.dist.php .php-cs-fixer.cache composer.* tests run doc docs vendor vendor2 docker-compose.yml docker-compose.test.yml Makefile *.zip"
 result="$(pwd)/miguel.zip"
 
 rm -rf "$result"

--- a/.github/scripts/build-zip.sh
+++ b/.github/scripts/build-zip.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 tmpdir=$(mktemp -d)
-ignore=".git .github .idea .vscode .gitignore .php-cs-fixer.dist.php .php-cs-fixer.cache composer.* tests run doc docs vendor vendor2 docker-compose.yml docker-compose.test.yml Makefile *.zip"
+ignore=".git .github .idea .vscode .gitignore .dockerignore .php-cs-fixer.dist.php .php-cs-fixer.cache composer.* tests run doc docs vendor vendor2 docker Dockerfile.test docker-compose.yml docker-compose.test.yml Makefile .superpowers *.zip"
 result="$(pwd)/miguel.zip"
 
 rm -rf "$result"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # CHANGELOG
 
+## v1.3.0
+
+Added:
+
+- Native PrestaShop API endpoint via a module front controller (`index.php?fc=module&module=miguel&controller=api&resource=…`), routed through the shop's `index.php` so it is no longer blocked by Cloudflare/Apache rules against direct PHP access in `/modules/`.
+- The module now reports its endpoint URLs to Miguel on connect (`endpoints` in the connect payload).
+- Fallback API-token transport via the `X-Miguel-Token` header for environments that strip `Authorization`.
+
+Changed:
+
+- The legacy `orders.php`, `products.php`, and `order-state-callback.php` scripts now delegate to the shared dispatcher and are deprecated (kept for backward compatibility).
+
 ## v1.2.3
 
 Added:

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,19 @@
+# PrestaShop 1.7.8.x (the version seeded from vendor2) requires PHP <= 7.4.
+FROM php:7.4-cli-bullseye
+
+# Extensions required by PrestaShop core + the module test bootstrap.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        git unzip rsync default-mysql-client \
+        libpng-dev libfreetype6-dev libjpeg62-turbo-dev \
+        libzip-dev libicu-dev libxml2-dev libxslt1-dev libonig-dev \
+    && docker-php-ext-configure gd --with-freetype --with-jpeg \
+    && docker-php-ext-install -j"$(nproc)" \
+        gd pdo_mysql mysqli zip intl soap xsl bcmath exif gettext calendar mbstring \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+
+# PrestaShop install + module test suite can be memory-hungry.
+RUN echo "memory_limit = -1" > /usr/local/etc/php/conf.d/zz-memory.ini
+
+WORKDIR /project

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,20 @@
+COMPOSE_TEST = docker compose -f docker-compose.test.yml
+
 build-zip:
 	bash .github/scripts/build-zip.sh
 
-phpunit:
-	./vendor/bin/phpunit -c ./tests/Unit/phpunit.xml
+# Run the PHPUnit suite entirely in Docker (no host PHP/MySQL needed).
+# Pass extra phpunit args via ARGS, e.g. `make test-docker ARGS="--filter ApiDispatcherTest"`.
+test-docker:
+	$(COMPOSE_TEST) run --rm phpunit $(ARGS)
+
+# Build (or rebuild) the test image.
+test-docker-build:
+	$(COMPOSE_TEST) build
+
+# Tear down the test stack and drop the cached PrestaShop install + DB volumes.
+test-docker-clean:
+	$(COMPOSE_TEST) down -v
+
+# Alias: `make test` runs the Docker suite.
+test: test-docker

--- a/controllers/front/api.php
+++ b/controllers/front/api.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * 2023 Servantes
+ *
+ * This file is licenced under the Software License Agreement.
+ * With the purchase or the installation of the software in your application
+ * you accept the licence agreement.
+ *
+ * You must not modify, adapt or create derivative works of this source code
+ *
+ *  @author Roman Kříž <roman.kriz@servantes.cz>
+ *  @copyright  2022 - 2024 Servantes
+ *  @license LICENSE.txt
+ */
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+use Miguel\Utils\MiguelApiDispatcher;
+
+class MiguelApiModuleFrontController extends ModuleFrontController
+{
+    /**
+     * @var bool no customer login required; the bearer token authenticates
+     */
+    public $auth = false;
+
+    /**
+     * @var bool Miguel always calls over HTTPS
+     */
+    public $ssl = true;
+
+    public function initContent()
+    {
+        $dispatcher = new MiguelApiDispatcher($this->module);
+        $response = $dispatcher->dispatch(
+            Tools::getValue('resource'),
+            isset($_SERVER['REQUEST_METHOD']) ? $_SERVER['REQUEST_METHOD'] : 'GET',
+            $_GET,
+            $this->module->readFileContent('php://input')
+        );
+
+        // Discard any buffered theme/partial output so the response is pure JSON.
+        while (ob_get_level() > 0) {
+            ob_end_clean();
+        }
+
+        header('Content-Type: application/json; charset=UTF-8');
+        header('User-Agent: ' . $this->module->getUserAgent());
+
+        echo json_encode($response);
+        exit;
+    }
+
+    /**
+     * Keep the API reachable while the shop is in maintenance mode.
+     * The parent implementation renders the 503 maintenance page and exits.
+     */
+    protected function displayMaintenancePage()
+    {
+        // intentionally left blank
+    }
+}

--- a/controllers/front/api.php
+++ b/controllers/front/api.php
@@ -32,17 +32,20 @@ class MiguelApiModuleFrontController extends ModuleFrontController
 
     public function initContent()
     {
+        /** @var Miguel $module */
+        $module = $this->module;
+
         $resource = Tools::getValue('resource');
         if (!is_string($resource)) {
             $resource = '';
         }
 
-        $dispatcher = new MiguelApiDispatcher($this->module);
+        $dispatcher = new MiguelApiDispatcher($module);
         $response = $dispatcher->dispatch(
             $resource,
             isset($_SERVER['REQUEST_METHOD']) ? $_SERVER['REQUEST_METHOD'] : 'GET',
             $_GET,
-            $this->module->readFileContent('php://input')
+            $module->readFileContent('php://input')
         );
 
         // Discard any buffered theme/partial output so the response is pure JSON.
@@ -51,7 +54,7 @@ class MiguelApiModuleFrontController extends ModuleFrontController
         }
 
         header('Content-Type: application/json; charset=UTF-8');
-        header('User-Agent: ' . $this->module->getUserAgent());
+        header('User-Agent: ' . $module->getUserAgent());
 
         echo json_encode($response);
         exit;

--- a/controllers/front/api.php
+++ b/controllers/front/api.php
@@ -32,9 +32,14 @@ class MiguelApiModuleFrontController extends ModuleFrontController
 
     public function initContent()
     {
+        $resource = Tools::getValue('resource');
+        if (!is_string($resource)) {
+            $resource = '';
+        }
+
         $dispatcher = new MiguelApiDispatcher($this->module);
         $response = $dispatcher->dispatch(
-            Tools::getValue('resource'),
+            $resource,
             isset($_SERVER['REQUEST_METHOD']) ? $_SERVER['REQUEST_METHOD'] : 'GET',
             $_GET,
             $this->module->readFileContent('php://input')
@@ -57,6 +62,15 @@ class MiguelApiModuleFrontController extends ModuleFrontController
      * The parent implementation renders the 503 maintenance page and exits.
      */
     protected function displayMaintenancePage()
+    {
+        // intentionally left blank
+    }
+
+    /**
+     * Keep the API reachable regardless of geolocation restrictions — the bearer
+     * token is the access gate. The parent renders a 403 restricted-country page.
+     */
+    protected function displayRestrictedCountryPage()
     {
         // intentionally left blank
     }

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,42 @@
+services:
+  db:
+    # PrestaShop 1.7.8 (the seeded version) installs cleanly only on MySQL 5.7,
+    # matching the CI 1.7.8 lane. mysql:5.7 has no arm64 image, so emulate amd64.
+    image: mysql:5.7
+    platform: linux/amd64
+    environment:
+      MYSQL_ROOT_PASSWORD: password
+      MYSQL_DATABASE: prestashop
+    volumes:
+      - ps_db_data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-ppassword"]
+      interval: 5s
+      timeout: 5s
+      retries: 40
+
+  phpunit:
+    build:
+      context: .
+      dockerfile: Dockerfile.test
+    depends_on:
+      db:
+        condition: service_healthy
+    volumes:
+      - .:/project
+      # PrestaShop is cloned + installed into this named volume once, then reused;
+      # the host tree (including the corrupt host vendor2) is never touched.
+      - ps_prestashop:/project/vendor2
+    environment:
+      DB_HOST: db
+      DB_PORT: "3306"
+      DB_USER: root
+      DB_PASS: password
+      DB_NAME: prestashop
+      # 1.7.8.x pairs with PHP 7.4 (Dockerfile.test) + MySQL 5.7 (db service).
+      PRESTASHOP_VERSION: "1.7.8.10"
+    entrypoint: ["/project/docker/test-entrypoint.sh"]
+
+volumes:
+  ps_db_data:
+  ps_prestashop:

--- a/docker/test-entrypoint.sh
+++ b/docker/test-entrypoint.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+#
+# Entrypoint for the containerized PHPUnit run (docker-compose.test.yml).
+#
+# Runs the module's test suite entirely in Docker (no host PHP/MySQL needed):
+#   1. wait for the MySQL service
+#   2. ensure a clean PrestaShop checkout in the cache volume (git clone once)
+#   3. install PrestaShop against the container DB (once per DB volume)
+#   4. create the test DB as a copy of the fresh install
+#   5. place the module under PrestaShop/modules/miguel (like the CI zip step)
+#   6. run PHPUnit from PrestaShop's context (PrestaShop's phpunit binary)
+#
+# Args passed to `docker compose run --rm phpunit <args>` are forwarded to phpunit,
+# e.g. `make test-docker ARGS="--filter ApiDispatcherTest"`.
+set -euo pipefail
+
+DB_HOST="${DB_HOST:-db}"
+DB_PORT="${DB_PORT:-3306}"
+DB_USER="${DB_USER:-root}"
+DB_PASS="${DB_PASS:-password}"
+DB_NAME="${DB_NAME:-prestashop}"
+TEST_DB_NAME="test_${DB_NAME}"
+PRESTASHOP_VERSION="${PRESTASHOP_VERSION:-1.7.8.10}"
+
+PS_DIR="/project/vendor2/PrestaShop"
+DB_STRUCTURE="$PS_DIR/install-dev/data/db_structure.sql"
+MODULE_DEST="$PS_DIR/modules/miguel"
+INSTALL_MARKER="/project/vendor2/.miguel-docker-db-installed"
+
+log() { echo "==> $*"; }
+
+# The Debian MariaDB client defaults to TLS; disable it when the flag exists.
+MYSQL_SSL_FLAG=""
+if mysql --help 2>&1 | grep -q -- '--skip-ssl'; then
+    MYSQL_SSL_FLAG="--skip-ssl"
+fi
+
+mysql_cli() {
+    mysql $MYSQL_SSL_FLAG -h "$DB_HOST" -P "$DB_PORT" -u "$DB_USER" -p"$DB_PASS" "$@"
+}
+
+wait_for_db() {
+    log "Waiting for MySQL at ${DB_HOST}:${DB_PORT}..."
+    until mysql_cli -e "SELECT 1" >/dev/null 2>&1; do
+        sleep 2
+    done
+    log "MySQL ready."
+}
+
+# A valid checkout has the CLI installer and the PrestaShop test bootstrap.
+# (The base `shop` table lives in the installer's upgrade SQL, not db_structure.sql,
+# so a real post-install check happens in install_db after index_cli runs.)
+prestashop_is_valid() {
+    [ -f "$PS_DIR/install-dev/index_cli.php" ] &&
+        [ -f "$PS_DIR/tests-legacy/bootstrap.php" ]
+}
+
+ensure_prestashop() {
+    if prestashop_is_valid; then
+        log "PrestaShop present in cache volume."
+        return 0
+    fi
+    log "Cloning PrestaShop ${PRESTASHOP_VERSION} (one-time, slow)..."
+    rm -rf "$PS_DIR"
+    git clone --depth 1 --branch "$PRESTASHOP_VERSION" \
+        https://github.com/PrestaShop/PrestaShop "$PS_DIR"
+    log "Installing PrestaShop composer dependencies..."
+    composer install --working-dir="$PS_DIR" \
+        --prefer-dist --no-progress --no-ansi --no-interaction
+    prestashop_is_valid || { log "ERROR: cloned PrestaShop is still invalid."; exit 1; }
+    log "PrestaShop ready."
+}
+
+# Test-DB fixes from .github/scripts/install-prestashop.sh, applied once.
+patch_prestashop_source() {
+    local dump="$PS_DIR/src/PrestaShopBundle/Install/DatabaseDump.php"
+    if [ -f "$dump" ] && ! grep -q '#throw new Exception' "$dump"; then
+        sed -i 's/throw new Exception/#throw new Exception/g' "$dump"
+    fi
+    local datalang="$PS_DIR/classes/lang/DataLang.php"
+    [ -f "$datalang" ] && sed -i "s/SymfonyContainer::getInstance()->get('translator')/\\\\Context::getContext()->getTranslator()/g" "$datalang"
+    local language="$PS_DIR/classes/Language.php"
+    if [ -f "$language" ]; then
+        sed -i "s/SymfonyContainer::getInstance()->get('translator')/\\\\Context::getContext()->getTranslator()/g" "$language"
+        sed -i "s/\$sfContainer->get('translator')/\\\\Context::getContext()->getTranslator()/g" "$language"
+    fi
+}
+
+# Install the pristine `prestashop` DB once (cached via marker across runs).
+# The tests never touch this DB directly — they run against test_prestashop,
+# which is a fresh copy of it (see refresh_test_db). This keeps prestashop clean
+# as the reset source.
+install_base() {
+    if [ -f "$INSTALL_MARKER" ]; then
+        log "PrestaShop base already installed (marker present); skipping install."
+        return 0
+    fi
+
+    patch_prestashop_source
+
+    log "Installing PrestaShop into ${DB_HOST}/${DB_NAME} (first run, may take a few minutes)..."
+    mysql_cli -e "DROP DATABASE IF EXISTS \`${DB_NAME}\`;"
+    rm -f "$PS_DIR/config/settings.inc.php" "$PS_DIR/app/config/parameters.php" "$PS_DIR/app/config/parameters.yml"
+    rm -rf "$PS_DIR"/var/cache/* "$PS_DIR"/var/logs/* 2>/dev/null || true
+
+    (
+        cd "$PS_DIR/install-dev"
+        php index_cli.php \
+            --language=en --country=fr --domain=localhost \
+            --db_server="${DB_HOST}:${DB_PORT}" --db_name="${DB_NAME}" \
+            --db_user="${DB_USER}" --db_password="${DB_PASS}" --db_create=1 \
+            --name=prestashop.unit.test --email=demo@prestashop.com --password=prestashop_demo
+    )
+
+    if ! mysql_cli -N -e "SELECT 1 FROM information_schema.tables WHERE table_schema='${DB_NAME}' AND table_name='ps_shop' LIMIT 1;" | grep -q 1; then
+        log "ERROR: install incomplete — ps_shop table missing."
+        exit 1
+    fi
+
+    touch "$INSTALL_MARKER"
+    log "PrestaShop base installed."
+}
+
+# Reset the test database from the pristine install before every run, so each
+# `make test-docker` starts from a clean, isolated state (the module's tests do
+# not restore the DB themselves).
+refresh_test_db() {
+    log "Resetting ${TEST_DB_NAME} from a clean ${DB_NAME}..."
+    mysql_cli -e "DROP DATABASE IF EXISTS \`${TEST_DB_NAME}\`; CREATE DATABASE \`${TEST_DB_NAME}\` CHARACTER SET utf8mb4;"
+    mysqldump $MYSQL_SSL_FLAG -h "$DB_HOST" -P "$DB_PORT" -u "$DB_USER" -p"$DB_PASS" \
+        --no-tablespaces --skip-triggers "${DB_NAME}" | mysql_cli "${TEST_DB_NAME}"
+}
+
+place_module() {
+    log "Placing module under PrestaShop/modules/miguel..."
+    mkdir -p "$MODULE_DEST"
+    rsync -a --delete \
+        --exclude '.git' --exclude 'vendor2' --exclude 'vendor' \
+        --exclude 'run' --exclude 'node_modules' --exclude '*.zip' \
+        /project/ "$MODULE_DEST/"
+}
+
+run_phpunit() {
+    log "Running PHPUnit..."
+    cd "$PS_DIR"
+    exec composer exec phpunit -- -c modules/miguel/tests/Unit/phpunit.xml "$@"
+}
+
+wait_for_db
+ensure_prestashop
+install_base
+refresh_test_db
+place_module
+run_phpunit "$@"

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,0 +1,549 @@
+openapi: 3.0.3
+info:
+  title: Miguel PrestaShop API
+  version: "1"
+  license:
+    name: Proprietary — see LICENSE.txt
+    url: https://github.com/servantes-io/miguel-prestashop/blob/main/LICENSE.txt
+  description: >
+    HTTP API exposed by the Miguel PrestaShop module for the Miguel backend.
+    Three endpoints: list updated orders, list products, and a callback that
+    switches a PrestaShop order status.
+
+
+    ## Routing & URLs
+
+    Each endpoint is reachable at two equivalent URLs that hit the same handler
+    with the same request/response contract:
+
+
+    * **Recommended — module front controller** (routed through the shop's
+      `index.php`, so it is not blocked by Cloudflare/Apache rules against direct
+      `.php` access in `/modules/`):
+
+      `{shop}/index.php?fc=module&module=miguel&controller=api&resource={resource}`
+
+      (or, with PrestaShop friendly URLs enabled, `{shop}/module/miguel/api?resource={resource}`)
+
+    * **Deprecated — direct-access scripts** (kept for backward compatibility,
+      scheduled for removal in a future major version): the paths documented
+      below — `/modules/miguel/orders.php`, `.../products.php`,
+      `.../order-state-callback.php`.
+
+
+    The `{resource}` values are `orders`, `products`, and `order-state-callback`.
+    The paths in this document use the direct-access form because an OpenAPI path
+    cannot contain a query string; the contract is identical for the recommended
+    front-controller URL. The module reports the exact per-resource
+    front-controller URLs to the Miguel backend in the `endpoints` object of the
+    `/v2/eshop/prestashop/connect` payload (`endpoints.orders`,
+    `endpoints.products`, `endpoints.orderStateCallback`).
+
+
+    ## Response contract
+
+    **Every** response is returned with HTTP status `200` and a JSON envelope
+    `{ "result": ..., "debug": "", ... }`. Errors are conveyed **in the body**
+    (`result: false` plus an `error` object), never via HTTP status codes — the
+    backend must inspect the envelope, not the HTTP status.
+
+
+    ## Authentication
+
+    Every request must carry the API token configured in the module settings,
+    either as `Authorization: Bearer <token>` (preferred) or, for environments
+    where a proxy strips the Authorization header, as the `X-Miguel-Token: <token>`
+    header. A missing token yields `api_key.not_set`; a wrong token yields
+    `api_key.invalid`.
+
+servers:
+  - url: https://{domain}{basePath}
+    variables:
+      domain:
+        default: example.com
+        description: Shop domain (host).
+      basePath:
+        default: ""
+        description: >
+          PrestaShop base URI for shops installed in a subfolder (PrestaShop
+          `__PS_BASE_URI__`). Empty for a root install, e.g. "/shop" otherwise.
+
+security:
+  - bearerAuth: []
+  - miguelTokenAuth: []
+
+tags:
+  - name: orders
+    description: Read orders.
+  - name: products
+    description: Read the product catalogue.
+  - name: callback
+    description: Order-status callback invoked by Miguel.
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      description: "Authorization: Bearer <token> — the API token from the module settings."
+    miguelTokenAuth:
+      type: apiKey
+      in: header
+      name: X-Miguel-Token
+      description: Fallback token header used when the Authorization header is stripped by a proxy.
+
+  schemas:
+    ApiError:
+      type: object
+      description: Error detail carried inside an error envelope.
+      required: [code, message]
+      properties:
+        code:
+          type: string
+          description: Machine-readable error code.
+          enum:
+            - api_key.not_set
+            - api_key.invalid
+            - module.disabled
+            - configuration.not_set
+            - argument.not_set
+            - payload.invalid
+            - resource.not_found
+            - method.not_allowed
+            - unknown.error
+          example: api_key.invalid
+        message:
+          type: string
+          description: Human-readable message.
+          example: API key invalid
+        data:
+          type: object
+          nullable: true
+          description: >
+            Optional extra context. Present only for some errors — e.g.
+            `api_key.not_set` includes the received request headers under `headers`.
+          additionalProperties: true
+
+    ErrorEnvelope:
+      type: object
+      description: Returned (with HTTP 200) for any failed request. Applies to every endpoint.
+      required: [result, debug, error]
+      properties:
+        result:
+          type: boolean
+          enum: [false]
+          example: false
+        debug:
+          type: string
+          description: Reserved, always an empty string (kept for backward compatibility).
+          example: ""
+        error:
+          $ref: '#/components/schemas/ApiError'
+
+    OrderProductPrice:
+      type: object
+      properties:
+        regular_without_vat:
+          type: number
+          format: float
+          description: Regular (list) unit price excluding VAT.
+          example: 199.0
+        sold_without_vat:
+          type: number
+          format: float
+          description: Actually sold unit price excluding VAT (after discounts).
+          example: 149.0
+
+    OrderProduct:
+      type: object
+      description: >
+        A single Miguel product line in an order. Only products with a reference
+        (Miguel product code) are included; other lines are omitted. Pack items
+        are expanded to their individual Miguel sub-products with the pack price
+        distributed proportionally.
+      properties:
+        code:
+          type: string
+          description: Product reference (Miguel product code).
+          example: "9788024271101"
+        price:
+          $ref: '#/components/schemas/OrderProductPrice'
+
+    OrderUser:
+      type: object
+      properties:
+        id:
+          type: string
+          description: PrestaShop customer ID (as a string).
+          example: "42"
+        full_name:
+          type: string
+          example: Jan Novák
+        email:
+          type: string
+          format: email
+          example: jan@example.com
+        address:
+          type: string
+          description: >
+            Invoice address flattened to a single comma-separated string
+            (company, name, address1, address2, postcode, city, country — empty
+            parts omitted).
+          example: "Jan Novák, Václavské náměstí 1, 11000, Praha, CZ"
+        lang:
+          type: string
+          description: Customer language ISO code.
+          example: cs
+
+    Order:
+      type: object
+      description: >
+        An order that contains at least one Miguel product. Orders with no Miguel
+        products are omitted from the list.
+      properties:
+        code:
+          type: string
+          description: Order reference.
+          example: XKBKNABJK
+        user:
+          $ref: '#/components/schemas/OrderUser'
+        purchase_date:
+          type: string
+          format: date-time
+          description: Order creation date (ISO 8601).
+          example: "2024-01-15T10:30:00+0000"
+        update_date:
+          type: string
+          format: date-time
+          description: Order last-modification date (ISO 8601). Present in the orders listing.
+          example: "2024-01-16T08:05:00+0000"
+        paid:
+          type: boolean
+          description: Whether the order has been paid.
+        currency_code:
+          type: string
+          description: ISO 4217 currency code of the order.
+          example: CZK
+        products:
+          type: array
+          items:
+            $ref: '#/components/schemas/OrderProduct'
+
+    OrdersResponse:
+      type: object
+      description: Successful response of the orders endpoint.
+      required: [result, debug, orders]
+      properties:
+        result:
+          type: boolean
+          enum: [true]
+          example: true
+        debug:
+          type: string
+          example: ""
+        orders:
+          type: array
+          items:
+            $ref: '#/components/schemas/Order'
+
+    Product:
+      type: object
+      description: >
+        A sellable product row. Products with combinations produce one row per
+        combination (with `id_product_attribute` set and the combination name
+        appended to `name`); simple products produce a single row with
+        `id_product_attribute` = 0.
+      properties:
+        id_product:
+          type: integer
+          example: 15
+        id_product_attribute:
+          type: integer
+          description: Combination ID, or 0 for a simple product / product without combinations.
+          example: 0
+        reference:
+          type: string
+          description: Product (or combination) reference; falls back to the product reference when the combination has none.
+          example: "9788024271101"
+        price:
+          type: number
+          format: float
+          description: Unit price including tax (3 decimal places).
+          example: 199.0
+        price_without_tax:
+          type: number
+          format: float
+          description: Unit price excluding tax (3 decimal places).
+          example: 164.463
+        tax_rate:
+          type: number
+          format: float
+          description: Product tax rate as a percentage.
+          example: 21.0
+        currency:
+          type: string
+          description: ISO 4217 code of the shop default currency the prices are expressed in.
+          example: CZK
+        name:
+          type: string
+          description: Product name; for combinations the attribute values are appended in parentheses.
+          example: "My eBook (Format: EPUB)"
+        active:
+          type: boolean
+          description: Whether the product is active/published.
+
+    ProductsResponse:
+      type: object
+      description: Successful response of the products endpoint.
+      required: [result, debug, products]
+      properties:
+        result:
+          type: boolean
+          enum: [true]
+          example: true
+        debug:
+          type: string
+          example: ""
+        products:
+          type: array
+          items:
+            $ref: '#/components/schemas/Product'
+
+    OrderStateCallbackProductFormat:
+      type: object
+      properties:
+        format:
+          type: string
+          description: Delivered file format.
+          example: epub
+
+    OrderStateCallbackProduct:
+      type: object
+      properties:
+        formats:
+          type: array
+          description: >
+            Delivered Miguel formats for this product. An empty array marks a
+            non-Miguel product in the order (used to detect mixed orders).
+          items:
+            $ref: '#/components/schemas/OrderStateCallbackProductFormat'
+
+    OrderStateCallbackRequest:
+      type: object
+      required: [code]
+      description: Callback payload sent by Miguel to switch a PrestaShop order status.
+      properties:
+        code:
+          type: string
+          description: Order reference to update.
+          example: XKBKNABJK
+        miguel_state:
+          type: string
+          description: >
+            Miguel-side processing state. The order status is only changed when
+            this equals `finished`.
+          example: finished
+        products:
+          type: array
+          description: Products in the order and their delivered formats.
+          items:
+            $ref: '#/components/schemas/OrderStateCallbackProduct'
+
+    OrderStateCallbackResponse:
+      type: object
+      description: >
+        Successful response of the order-state callback. Note: the `result` field
+        carries the outcome **string** (not a boolean) because the payload data
+        key is itself `result`.
+      required: [result, debug]
+      properties:
+        result:
+          type: string
+          description: Outcome of the state change.
+          enum:
+            - state changed
+            - "waiting for status: finished"
+            - no products
+            - auto change not set
+            - unknown order id
+            - multiple same order id
+            - "error: missing id_order"
+          example: state changed
+        debug:
+          type: string
+          example: ""
+
+paths:
+  /modules/miguel/orders.php:
+    get:
+      tags: [orders]
+      summary: List orders updated since a given date
+      operationId: getOrders
+      description: >
+        Returns every order whose `date_upd` is on or after `updated_since` and
+        that contains at least one Miguel product.
+
+
+        **Recommended URL:** `{shop}/index.php?fc=module&module=miguel&controller=api&resource=orders&updated_since=...`
+        (the front-controller form; this direct-access path is the deprecated
+        equivalent with an identical contract).
+      parameters:
+        - in: query
+          name: updated_since
+          required: true
+          schema:
+            type: string
+          description: >
+            Date/time threshold. Any value parseable by PHP `strtotime()` is
+            accepted (ISO 8601, `Y-m-d H:i:s`, Unix timestamp, relative strings).
+          example: "2024-01-01 00:00:00"
+      responses:
+        "200":
+          description: >
+            Always HTTP 200 — either the orders envelope or an error envelope
+            (missing `updated_since` → `argument.not_set`; auth failures →
+            `api_key.not_set` / `api_key.invalid`).
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/OrdersResponse'
+                  - $ref: '#/components/schemas/ErrorEnvelope'
+              examples:
+                success:
+                  value:
+                    result: true
+                    debug: ""
+                    orders:
+                      - code: XKBKNABJK
+                        user:
+                          id: "42"
+                          full_name: Jan Novák
+                          email: jan@example.com
+                          address: "Jan Novák, Václavské náměstí 1, 11000, Praha, CZ"
+                          lang: cs
+                        purchase_date: "2024-01-15T10:30:00+0000"
+                        update_date: "2024-01-16T08:05:00+0000"
+                        paid: true
+                        currency_code: CZK
+                        products:
+                          - code: "9788024271101"
+                            price:
+                              regular_without_vat: 199.0
+                              sold_without_vat: 149.0
+                argument_missing:
+                  value:
+                    result: false
+                    debug: ""
+                    error:
+                      code: argument.not_set
+                      message: Argument updated_since not set
+
+  /modules/miguel/products.php:
+    get:
+      tags: [products]
+      summary: List all products with prices
+      operationId: getProducts
+      description: >
+        Returns all products (and one row per combination) with tax-included and
+        tax-excluded unit prices, tax rate, and currency.
+
+
+        **Recommended URL:** `{shop}/index.php?fc=module&module=miguel&controller=api&resource=products`
+        (the front-controller form; this direct-access path is the deprecated
+        equivalent with an identical contract).
+      responses:
+        "200":
+          description: >
+            Always HTTP 200 — either the products envelope or an error envelope
+            (auth failures → `api_key.not_set` / `api_key.invalid`).
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/ProductsResponse'
+                  - $ref: '#/components/schemas/ErrorEnvelope'
+              examples:
+                success:
+                  value:
+                    result: true
+                    debug: ""
+                    products:
+                      - id_product: 15
+                        id_product_attribute: 0
+                        reference: "9788024271101"
+                        price: 199.0
+                        price_without_tax: 164.463
+                        tax_rate: 21.0
+                        currency: CZK
+                        name: My eBook
+                        active: true
+
+  /modules/miguel/order-state-callback.php:
+    post:
+      tags: [callback]
+      summary: Switch a PrestaShop order status
+      operationId: orderStateCallback
+      description: >
+        Called by Miguel when processing of an order finishes, to move the
+        PrestaShop order to the configured status. The status is changed only when
+        `miguel_state` is `finished` and the module's automatic status switching is
+        configured; otherwise a descriptive outcome string is returned (still HTTP
+        200; `result: false` only on validation/auth errors).
+
+
+        **Recommended URL:** `{shop}/index.php?fc=module&module=miguel&controller=api&resource=order-state-callback`
+        (the front-controller form; this direct-access path is the deprecated
+        equivalent with an identical contract).
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrderStateCallbackRequest'
+            example:
+              code: XKBKNABJK
+              miguel_state: finished
+              products:
+                - formats:
+                    - format: epub
+                    - format: pdf
+      responses:
+        "200":
+          description: >
+            Always HTTP 200 — either the callback outcome envelope or an error
+            envelope (`payload.invalid` for a missing body / missing `code`,
+            `method.not_allowed` for a non-POST request, auth failures, etc.).
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/OrderStateCallbackResponse'
+                  - $ref: '#/components/schemas/ErrorEnvelope'
+              examples:
+                state_changed:
+                  value:
+                    result: state changed
+                    debug: ""
+                waiting:
+                  value:
+                    result: "waiting for status: finished"
+                    debug: ""
+                unknown_order:
+                  value:
+                    result: unknown order id
+                    debug: ""
+                missing_payload:
+                  value:
+                    result: false
+                    debug: ""
+                    error:
+                      code: payload.invalid
+                      message: "Invalid payload: payload is required"
+                missing_code:
+                  value:
+                    result: false
+                    debug: ""
+                    error:
+                      code: payload.invalid
+                      message: "Invalid payload: code not set"

--- a/docs/superpowers/plans/2026-07-18-module-front-controller-api.md
+++ b/docs/superpowers/plans/2026-07-18-module-front-controller-api.md
@@ -1,0 +1,910 @@
+# Module Front-Controller API Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Serve the three Miguel API endpoints through a native PrestaShop module front controller (routed via root `index.php`) so they stop being blocked by Cloudflare/Apache rules against executable PHP in `/modules/`, while keeping the legacy direct-access scripts working during the transition.
+
+**Architecture:** A single dispatcher front controller (`controllers/front/api.php`) routes on a `resource` query parameter to shared routing logic in a new `MiguelApiDispatcher` class. Both the front controller and the (now thin) legacy scripts delegate to that dispatcher, giving one source of truth for validation and routing. The module reports its endpoint URLs to the Miguel backend on connect so the backend no longer hardcodes paths.
+
+**Tech Stack:** PHP 7.1+, PrestaShop 1.7 / 8 / 9 module APIs (`ModuleFrontController`, `Link::getModuleLink`), PHPUnit for tests.
+
+## Global Constraints
+
+- PHP floor: `>=7.1.0` — no PHP 7.4+/8.0+ only syntax (no arrow functions, no typed properties, no `??=`, no named args, no union types in signatures).
+- PrestaShop compatibility: `1.7`–`9.99.99` (`ps_versions_compliancy`). Code must work on PS 1.7, 8, and 9.
+- All new `src/` and `controllers/` PHP files start with `if (!defined('_PS_VERSION_')) { exit; }` after the license header (follow existing file headers verbatim in style).
+- New utility classes live in the `Miguel\Utils` namespace (matches existing `src/utils/*`).
+- Response contract is **HTTP 200 + JSON envelope** for every outcome (success and error). Never emit real HTTP error status codes — the backend parser depends on the envelope.
+- Resource identifiers are exactly: `orders`, `products`, `order-state-callback`. These strings are hardcoded on the backend — do not rename.
+- Test environment: DB-backed tests extend `Tests\Unit\Utility\DatabaseTestCase` and require the dockerized test stack. Bring it up and run the full suite with `make test`. Run a single test with `vendor/bin/phpunit -c tests/Unit/phpunit.xml --filter <TestName>` once the environment (MySQL + PrestaShop in `vendor2/PrestaShop`) is available.
+- Bump version to `1.3.0` (done in the final task) — do not touch `$this->version` in intermediate tasks.
+
+---
+
+## File Structure
+
+- **Create** `src/utils/miguel-api-dispatcher.php` — `Miguel\Utils\MiguelApiDispatcher`; validates access, enforces HTTP method, routes a resource to the right module method, returns a `MiguelApiResponse`. Never echoes.
+- **Create** `controllers/front/api.php` — `MiguelApiModuleFrontController`; thin adapter that gathers request inputs, calls the dispatcher, emits raw JSON, and keeps working during maintenance mode.
+- **Modify** `src/utils/miguel-api-error.php` — add `resourceNotFound()` and `methodNotAllowed()` factories.
+- **Modify** `miguel.php` — `require_once` the dispatcher; add `getCustomTokenHeader()` + `X-Miguel-Token` fallback in `getBearerToken()`; add `endpoints` map in `getPrestashopDetails()`; bump version.
+- **Modify** `orders.php`, `products.php`, `order-state-callback.php` — reduce to thin shims delegating to the dispatcher; mark `@deprecated`.
+- **Create** tests: `tests/Unit/ApiErrorTest.php`, `tests/Unit/BearerTokenTest.php`, `tests/Unit/ApiDispatcherTest.php`, `tests/Unit/PrestashopDetailsTest.php`.
+- **Modify** `CHANGELOG.md`, `.github/scripts/build-zip.sh` (exclude `docs/` from the shipped zip).
+
+---
+
+## Task 1: New API error types
+
+**Files:**
+- Modify: `src/utils/miguel-api-error.php`
+- Test: `tests/Unit/ApiErrorTest.php`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `MiguelApiError::resourceNotFound(string $resource): MiguelApiError` → code `resource.not_found`, message `Resource <resource> not found`.
+  - `MiguelApiError::methodNotAllowed(string $method): MiguelApiError` → code `method.not_allowed`, message `Method <method> not allowed`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/Unit/ApiErrorTest.php`:
+
+```php
+<?php
+
+namespace Tests\Unit;
+
+use Miguel\Utils\MiguelApiError;
+use PHPUnit\Framework\TestCase;
+
+class ApiErrorTest extends TestCase
+{
+    public function testResourceNotFound()
+    {
+        $error = MiguelApiError::resourceNotFound('widgets');
+
+        $this->assertSame('resource.not_found', $error->getCode());
+        $this->assertSame('Resource widgets not found', $error->getMessage());
+    }
+
+    public function testMethodNotAllowed()
+    {
+        $error = MiguelApiError::methodNotAllowed('DELETE');
+
+        $this->assertSame('method.not_allowed', $error->getCode());
+        $this->assertSame('Method DELETE not allowed', $error->getMessage());
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `vendor/bin/phpunit -c tests/Unit/phpunit.xml --filter ApiErrorTest`
+Expected: FAIL — `Call to undefined method Miguel\Utils\MiguelApiError::resourceNotFound()`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/utils/miguel-api-error.php`, add these two factories immediately before the existing `unknownError()` method:
+
+```php
+    public static function resourceNotFound($resource): MiguelApiError
+    {
+        return new self('resource.not_found', "Resource $resource not found");
+    }
+
+    public static function methodNotAllowed($method): MiguelApiError
+    {
+        return new self('method.not_allowed', "Method $method not allowed");
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `vendor/bin/phpunit -c tests/Unit/phpunit.xml --filter ApiErrorTest`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/miguel-api-error.php tests/Unit/ApiErrorTest.php
+git commit -m "feat: add resourceNotFound and methodNotAllowed API errors"
+```
+
+---
+
+## Task 2: X-Miguel-Token fallback for auth
+
+**Files:**
+- Modify: `miguel.php` (method `getBearerToken()` near line 831; add new `getCustomTokenHeader()`)
+- Test: `tests/Unit/BearerTokenTest.php`
+
+**Interfaces:**
+- Consumes: existing `getallheaders()` polyfill (already required by `miguel.php`).
+- Produces:
+  - `Miguel::getCustomTokenHeader(): string|false` — token from the `X-Miguel-Token` header, else `false`.
+  - `Miguel::getBearerToken()` now returns the custom-header token when the `Authorization` bearer is absent.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/Unit/BearerTokenTest.php`:
+
+```php
+<?php
+
+namespace Tests\Unit;
+
+use Miguel;
+use PHPUnit\Framework\TestCase;
+
+class BearerTokenTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        unset($_SERVER['Authorization'], $_SERVER['HTTP_AUTHORIZATION'], $_SERVER['HTTP_X_MIGUEL_TOKEN']);
+    }
+
+    protected function tearDown(): void
+    {
+        unset($_SERVER['Authorization'], $_SERVER['HTTP_AUTHORIZATION'], $_SERVER['HTTP_X_MIGUEL_TOKEN']);
+        parent::tearDown();
+    }
+
+    public function testReadsBearerFromAuthorizationHeader()
+    {
+        $_SERVER['Authorization'] = 'Bearer abc123';
+
+        $module = new Miguel();
+
+        $this->assertSame('abc123', $module->getBearerToken());
+    }
+
+    public function testFallsBackToCustomHeader()
+    {
+        $_SERVER['HTTP_X_MIGUEL_TOKEN'] = 'abc123';
+
+        $module = new Miguel();
+
+        $this->assertSame('abc123', $module->getBearerToken());
+    }
+
+    public function testReturnsFalseWhenNoToken()
+    {
+        $module = new Miguel();
+
+        $this->assertFalse($module->getBearerToken());
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `vendor/bin/phpunit -c tests/Unit/phpunit.xml --filter BearerTokenTest`
+Expected: FAIL — `testFallsBackToCustomHeader` fails (returns `false`, expected `'abc123'`).
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `miguel.php`, replace the existing `getBearerToken()` method body so it falls through to the custom header, and add `getCustomTokenHeader()` right after it:
+
+```php
+    public function getBearerToken()
+    {
+        $headers = $this->getAuthorizationHeader();
+        // HEADER: Get the access token from the header
+        if (!empty($headers)) {
+            if (preg_match('/Bearer\s(\S+)/i', $headers, $matches)) {
+                return $matches[1];
+            }
+        }
+
+        // Fallback: some proxies strip the Authorization header. Accept the same
+        // token via the X-Miguel-Token custom header, which is stripped far less often.
+        $customToken = $this->getCustomTokenHeader();
+        if (!empty($customToken)) {
+            return $customToken;
+        }
+
+        return false;
+    }
+
+    /**
+     * Reads the API token from the X-Miguel-Token custom header. Used as a fallback
+     * when a proxy strips the Authorization header.
+     *
+     * @return string|false
+     */
+    public function getCustomTokenHeader()
+    {
+        if (isset($_SERVER['HTTP_X_MIGUEL_TOKEN'])) {
+            return trim($_SERVER['HTTP_X_MIGUEL_TOKEN']);
+        }
+
+        $headers = getallheaders();
+        if (is_array($headers)) {
+            foreach ($headers as $key => $value) {
+                if (strtolower($key) === 'x-miguel-token') {
+                    return trim($value);
+                }
+            }
+        }
+
+        return false;
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `vendor/bin/phpunit -c tests/Unit/phpunit.xml --filter BearerTokenTest`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add miguel.php tests/Unit/BearerTokenTest.php
+git commit -m "feat: accept API token via X-Miguel-Token header fallback"
+```
+
+---
+
+## Task 3: MiguelApiDispatcher (shared routing)
+
+**Files:**
+- Create: `src/utils/miguel-api-dispatcher.php`
+- Modify: `miguel.php` (add `require_once` for the new file, alongside the other `src/utils` requires near lines 15-20)
+- Test: `tests/Unit/ApiDispatcherTest.php`
+
+**Interfaces:**
+- Consumes: `Miguel::validateApiAccess()`, `Miguel::getUpdatedOrders($updated_since)`, `Miguel::getAllProducts()`, `Miguel::setOrderStates(array $data)`; `MiguelApiResponse::success()/error()`; `MiguelApiError::*` (incl. `resourceNotFound`, `methodNotAllowed` from Task 1).
+- Produces:
+  - `MiguelApiDispatcher::__construct(\Miguel $module)`
+  - `MiguelApiDispatcher::dispatch(string $resource, string $method, array $get, string $rawBody): MiguelApiResponse` — auth first, then method check, then resource routing. Never echoes.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/Unit/ApiDispatcherTest.php`:
+
+```php
+<?php
+
+namespace Tests\Unit;
+
+use Miguel;
+use Miguel\Utils\MiguelApiDispatcher;
+use Miguel\Utils\MiguelSettings;
+use Tests\Unit\Utility\DatabaseTestCase;
+
+class ApiDispatcherTest extends DatabaseTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        unset($_SERVER['Authorization'], $_SERVER['HTTP_AUTHORIZATION'], $_SERVER['HTTP_X_MIGUEL_TOKEN']);
+
+        MiguelSettings::setEnabled(true);
+        MiguelSettings::save(MiguelSettings::API_TOKEN_PRODUCTION_KEY, '1234');
+    }
+
+    protected function tearDown(): void
+    {
+        unset($_SERVER['Authorization'], $_SERVER['HTTP_AUTHORIZATION'], $_SERVER['HTTP_X_MIGUEL_TOKEN']);
+        parent::tearDown();
+    }
+
+    private function dispatcher(): MiguelApiDispatcher
+    {
+        return new MiguelApiDispatcher(new Miguel());
+    }
+
+    public function testUnknownResourceReturnsResourceNotFound()
+    {
+        $_SERVER['Authorization'] = 'Bearer 1234';
+
+        $response = $this->dispatcher()->dispatch('widgets', 'GET', [], '');
+
+        $this->assertFalse($response->getResult());
+        $this->assertSame('resource.not_found', $response->getData()->getCode());
+    }
+
+    public function testWrongMethodReturnsMethodNotAllowed()
+    {
+        $_SERVER['Authorization'] = 'Bearer 1234';
+
+        $response = $this->dispatcher()->dispatch('order-state-callback', 'GET', [], '');
+
+        $this->assertFalse($response->getResult());
+        $this->assertSame('method.not_allowed', $response->getData()->getCode());
+    }
+
+    public function testOrdersWithoutUpdatedSinceReturnsArgumentNotSet()
+    {
+        $_SERVER['Authorization'] = 'Bearer 1234';
+
+        $response = $this->dispatcher()->dispatch('orders', 'GET', [], '');
+
+        $this->assertFalse($response->getResult());
+        $this->assertSame('argument.not_set', $response->getData()->getCode());
+    }
+
+    public function testInvalidTokenReturnsApiKeyInvalid()
+    {
+        $_SERVER['Authorization'] = 'Bearer wrong';
+
+        $response = $this->dispatcher()->dispatch('products', 'GET', [], '');
+
+        $this->assertFalse($response->getResult());
+        $this->assertSame('api_key.invalid', $response->getData()->getCode());
+    }
+
+    public function testProductsSucceedWithCustomHeaderToken()
+    {
+        $_SERVER['HTTP_X_MIGUEL_TOKEN'] = '1234';
+
+        $response = $this->dispatcher()->dispatch('products', 'GET', [], '');
+
+        $this->assertTrue($response->getResult());
+        $this->assertSame('products', $response->getDataKey());
+        $this->assertIsArray($response->getData());
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `vendor/bin/phpunit -c tests/Unit/phpunit.xml --filter ApiDispatcherTest`
+Expected: FAIL — `Class "Miguel\Utils\MiguelApiDispatcher" not found`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `src/utils/miguel-api-dispatcher.php`:
+
+```php
+<?php
+/**
+ * 2024 Servantes
+ *
+ * This file is licenced under the Software License Agreement.
+ * With the purchase or the installation of the software in your application
+ * you accept the licence agreement.
+ *
+ * You must not modify, adapt or create derivative works of this source code
+ *
+ *  @author Roman Kříž <roman.kriz@servantes.cz>
+ *  @copyright  2022 - 2024 Servantes
+ *  @license LICENSE.txt
+ */
+
+namespace Miguel\Utils;
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+/**
+ * Central routing/validation for the Miguel public API. Shared by the module
+ * front controller and the legacy direct-access scripts. Never echoes: it
+ * returns a MiguelApiResponse that the caller serializes.
+ */
+class MiguelApiDispatcher
+{
+    /**
+     * @var \Miguel
+     */
+    private $module;
+
+    public function __construct(\Miguel $module)
+    {
+        $this->module = $module;
+    }
+
+    /**
+     * @param string $resource one of: orders, products, order-state-callback
+     * @param string $method   HTTP method (GET/POST)
+     * @param array $get       query parameters
+     * @param string $rawBody  raw request body (for POST resources)
+     *
+     * @return MiguelApiResponse
+     */
+    public function dispatch($resource, $method, array $get, $rawBody)
+    {
+        $valid = $this->module->validateApiAccess();
+        if ($valid !== true) {
+            return $valid;
+        }
+
+        switch ($resource) {
+            case 'orders':
+                if ($method !== 'GET') {
+                    return MiguelApiResponse::error(MiguelApiError::methodNotAllowed($method));
+                }
+                if (!isset($get['updated_since'])) {
+                    return MiguelApiResponse::error(MiguelApiError::argumentNotSet('updated_since'));
+                }
+
+                return MiguelApiResponse::success($this->module->getUpdatedOrders($get['updated_since']), 'orders');
+
+            case 'products':
+                if ($method !== 'GET') {
+                    return MiguelApiResponse::error(MiguelApiError::methodNotAllowed($method));
+                }
+
+                return MiguelApiResponse::success($this->module->getAllProducts(), 'products');
+
+            case 'order-state-callback':
+                if ($method !== 'POST') {
+                    return MiguelApiResponse::error(MiguelApiError::methodNotAllowed($method));
+                }
+                $data = json_decode($rawBody, true);
+                if (null === $data) {
+                    return MiguelApiResponse::error(MiguelApiError::invalidPayload('payload is required'));
+                }
+                if (!array_key_exists('code', $data)) {
+                    return MiguelApiResponse::error(MiguelApiError::invalidPayload('code not set'));
+                }
+
+                return MiguelApiResponse::success($this->module->setOrderStates($data), 'result');
+
+            default:
+                return MiguelApiResponse::error(MiguelApiError::resourceNotFound((string) $resource));
+        }
+    }
+}
+```
+
+Then in `miguel.php`, add the require alongside the other utils (after the `miguel-api-error.php` require near line 19):
+
+```php
+require_once 'src/utils/miguel-api-dispatcher.php';
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `vendor/bin/phpunit -c tests/Unit/phpunit.xml --filter ApiDispatcherTest`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/miguel-api-dispatcher.php miguel.php tests/Unit/ApiDispatcherTest.php
+git commit -m "feat: add MiguelApiDispatcher for shared API routing"
+```
+
+---
+
+## Task 4: Refactor legacy scripts to delegate to the dispatcher
+
+**Files:**
+- Modify: `orders.php`, `products.php`, `order-state-callback.php`
+- Test (regression, unchanged): `tests/Unit/OrdersTest.php`, `tests/Unit/ProductsTest.php`, `tests/Unit/OrderStateCallbackTest.php`
+
+**Interfaces:**
+- Consumes: `MiguelApiDispatcher::dispatch()` (Task 3); `Miguel::readFileContent()`, `Miguel::getUserAgent()`.
+- Produces: no new interface — the scripts keep emitting the same JSON envelope. Each script passes a literal HTTP method (they are single-method endpoints) so behavior is unchanged under CLI tests where `$_SERVER['REQUEST_METHOD']` is unset.
+
+- [ ] **Step 1: Run existing tests to confirm green baseline**
+
+Run: `vendor/bin/phpunit -c tests/Unit/phpunit.xml --filter "OrdersTest|ProductsTest|OrderStateCallbackTest"`
+Expected: PASS (all existing endpoint tests green before refactor).
+
+- [ ] **Step 2: Refactor `orders.php`**
+
+Replace the body below the license header + top-comment with:
+
+```php
+require_once __DIR__ . '/../../config/config.inc.php';
+require_once __DIR__ . '/miguel.php';
+
+use Miguel\Utils\MiguelApiDispatcher;
+
+// required thing for PrestaShop validator (needs to be after config.inc.php)
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+/*
+ * @deprecated Use the module front controller instead:
+ * index.php?fc=module&module=miguel&controller=api&resource=orders
+ * Kept for backward compatibility with older backend behavior; scheduled for
+ * removal in a future major version.
+ */
+
+$module = Miguel::createInstance();
+$context = Context::getContext();
+$context->controller = new FrontController();
+
+header('Content-Type: application/json; charset=UTF-8');
+header('User-Agent: ' . $module->getUserAgent());
+
+$dispatcher = new MiguelApiDispatcher($module);
+$output = $dispatcher->dispatch('orders', 'GET', $_GET, '');
+
+echo json_encode($output, JSON_PRETTY_PRINT);
+```
+
+- [ ] **Step 3: Refactor `products.php`**
+
+Replace the body below the license header + top-comment with:
+
+```php
+require_once __DIR__ . '/../../config/config.inc.php';
+require_once __DIR__ . '/miguel.php';
+
+use Miguel\Utils\MiguelApiDispatcher;
+
+// required thing for PrestaShop validator (needs to be after config.inc.php)
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+/*
+ * @deprecated Use the module front controller instead:
+ * index.php?fc=module&module=miguel&controller=api&resource=products
+ * Kept for backward compatibility; scheduled for removal in a future major version.
+ */
+
+$module = Miguel::createInstance();
+$context = Context::getContext();
+$context->controller = new FrontController();
+
+header('Content-Type: application/json; charset=UTF-8');
+header('User-Agent: ' . $module->getUserAgent());
+
+$dispatcher = new MiguelApiDispatcher($module);
+$output = $dispatcher->dispatch('products', 'GET', $_GET, '');
+
+echo json_encode($output, JSON_PRETTY_PRINT);
+```
+
+- [ ] **Step 4: Refactor `order-state-callback.php`**
+
+Replace the body below the license header + top-comment with:
+
+```php
+require_once __DIR__ . '/../../config/config.inc.php';
+require_once __DIR__ . '/miguel.php';
+
+use Miguel\Utils\MiguelApiDispatcher;
+
+// required thing for PrestaShop validator (needs to be after config.inc.php)
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+/*
+ * @deprecated Use the module front controller instead:
+ * index.php?fc=module&module=miguel&controller=api&resource=order-state-callback
+ * Kept for backward compatibility; scheduled for removal in a future major version.
+ */
+
+$module = Miguel::createInstance();
+$context = Context::getContext();
+$context->controller = new FrontController();
+
+header('Content-Type: application/json; charset=UTF-8');
+header('User-Agent: ' . $module->getUserAgent());
+
+$dispatcher = new MiguelApiDispatcher($module);
+$output = $dispatcher->dispatch('order-state-callback', 'POST', $_GET, $module->readFileContent('php://input'));
+
+echo json_encode($output);
+```
+
+- [ ] **Step 5: Run the endpoint tests to verify unchanged behavior**
+
+Run: `vendor/bin/phpunit -c tests/Unit/phpunit.xml --filter "OrdersTest|ProductsTest|OrderStateCallbackTest"`
+Expected: PASS — same output as the Step 1 baseline (the `MiguelMock` in `OrderStateCallbackTest` still supplies the body via `readFileContent`, and `validateApiAccess` is still honored).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add orders.php products.php order-state-callback.php
+git commit -m "refactor: legacy API scripts delegate to MiguelApiDispatcher"
+```
+
+---
+
+## Task 5: Dispatcher front controller
+
+**Files:**
+- Create: `controllers/front/api.php`
+- Verify: manual `curl` smoke test against the dev docker stack
+
+**Interfaces:**
+- Consumes: `MiguelApiDispatcher::dispatch()` (Task 3); `$this->module` (the `Miguel` instance PrestaShop injects); `Miguel::getUserAgent()`, `Miguel::readFileContent()`.
+- Produces: URL `index.php?fc=module&module=miguel&controller=api&resource=<resource>` returning the JSON envelope. No PHP interface consumed by later tasks.
+
+**Note on testing:** `initContent()` terminates the request with `exit`, so it cannot be exercised by an in-process PHPUnit test without killing the runner. The routing logic it depends on is fully covered by `ApiDispatcherTest` (Task 3); this task verifies the *wiring* (routing reaches the controller and returns pure JSON) with a `curl` smoke test.
+
+- [ ] **Step 1: Create the controller**
+
+Create `controllers/front/api.php`:
+
+```php
+<?php
+/**
+ * 2023 Servantes
+ *
+ * This file is licenced under the Software License Agreement.
+ * With the purchase or the installation of the software in your application
+ * you accept the licence agreement.
+ *
+ * You must not modify, adapt or create derivative works of this source code
+ *
+ *  @author Roman Kříž <roman.kriz@servantes.cz>
+ *  @copyright  2022 - 2024 Servantes
+ *  @license LICENSE.txt
+ */
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+use Miguel\Utils\MiguelApiDispatcher;
+
+class MiguelApiModuleFrontController extends ModuleFrontController
+{
+    /**
+     * @var bool no customer login required; the bearer token authenticates
+     */
+    public $auth = false;
+
+    /**
+     * @var bool Miguel always calls over HTTPS
+     */
+    public $ssl = true;
+
+    public function initContent()
+    {
+        $dispatcher = new MiguelApiDispatcher($this->module);
+        $response = $dispatcher->dispatch(
+            Tools::getValue('resource'),
+            isset($_SERVER['REQUEST_METHOD']) ? $_SERVER['REQUEST_METHOD'] : 'GET',
+            $_GET,
+            $this->module->readFileContent('php://input')
+        );
+
+        // Discard any buffered theme/partial output so the response is pure JSON.
+        while (ob_get_level() > 0) {
+            ob_end_clean();
+        }
+
+        header('Content-Type: application/json; charset=UTF-8');
+        header('User-Agent: ' . $this->module->getUserAgent());
+
+        echo json_encode($response);
+        exit;
+    }
+
+    /**
+     * Keep the API reachable while the shop is in maintenance mode.
+     * The parent implementation renders the 503 maintenance page and exits.
+     */
+    protected function displayMaintenancePage()
+    {
+        // intentionally left blank
+    }
+}
+```
+
+- [ ] **Step 2: Bring up the dev stack and install the module**
+
+```bash
+docker compose up -d
+```
+
+Then in the browser at `http://localhost:8082/admin` (admin folder `admin`), install/enable the **Miguel** module (Module Manager → Upload/enable). This mirrors a real shop; no API token needs to be configured for the smoke test in Step 3.
+
+- [ ] **Step 3: Smoke-test routing (no token → JSON error envelope)**
+
+Run:
+
+```bash
+curl -s "http://localhost:8082/index.php?fc=module&module=miguel&controller=api&resource=products"
+```
+
+Expected: a JSON body (not an HTML theme page, not a 404), specifically the auth error envelope:
+
+```json
+{"result":false,"debug":"","error":{"code":"api_key.not_set","message":"API key not set","data":{"headers":{ ... }}}}
+```
+
+Getting JSON back proves the request routed through root `index.php` to the controller and returned a pure JSON envelope — the core fix. (A wrong resource returns `resource.not_found`; a `POST` to `resource=order-state-callback` without a body returns `payload.invalid`.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add controllers/front/api.php
+git commit -m "feat: add MiguelApi front controller for native routing"
+```
+
+---
+
+## Task 6: Report endpoint URLs to the backend on connect
+
+**Files:**
+- Modify: `miguel.php` (method `getPrestashopDetails()` near line 609)
+- Test: `tests/Unit/PrestashopDetailsTest.php`
+
+**Interfaces:**
+- Consumes: `$this->context->link->getModuleLink('miguel', 'api', ['resource' => ...], true)`.
+- Produces: `getPrestashopDetails()` return array gains an `endpoints` key: `['orders' => <url>, 'products' => <url>, 'orderStateCallback' => <url>]`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/Unit/PrestashopDetailsTest.php`:
+
+```php
+<?php
+
+namespace Tests\Unit;
+
+use Miguel;
+use Tests\Unit\Utility\DatabaseTestCase;
+
+class PrestashopDetailsTest extends DatabaseTestCase
+{
+    public function testIncludesEndpointUrls()
+    {
+        $module = new Miguel();
+
+        $details = $module->getPrestashopDetails();
+
+        $this->assertArrayHasKey('endpoints', $details);
+        $this->assertArrayHasKey('orders', $details['endpoints']);
+        $this->assertArrayHasKey('products', $details['endpoints']);
+        $this->assertArrayHasKey('orderStateCallback', $details['endpoints']);
+
+        $this->assertStringContainsString('resource=orders', $details['endpoints']['orders']);
+        $this->assertStringContainsString('resource=products', $details['endpoints']['products']);
+        $this->assertStringContainsString('resource=order-state-callback', $details['endpoints']['orderStateCallback']);
+    }
+
+    public function testKeepsLegacyBaseFields()
+    {
+        $module = new Miguel();
+
+        $details = $module->getPrestashopDetails();
+
+        $this->assertArrayHasKey('baseUrl', $details);
+        $this->assertArrayHasKey('baseUri', $details);
+        $this->assertArrayHasKey('moduleVersion', $details);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `vendor/bin/phpunit -c tests/Unit/phpunit.xml --filter PrestashopDetailsTest`
+Expected: FAIL — `Failed asserting that an array has the key 'endpoints'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `miguel.php`, replace `getPrestashopDetails()` with:
+
+```php
+    public function getPrestashopDetails()
+    {
+        $ps = [];
+        $ps['psVersion'] = _PS_VERSION_;
+        $ps['moduleVersion'] = $this->version;
+        $ps['baseUrl'] = Tools::getShopDomainSsl(true);
+        $ps['baseUri'] = __PS_BASE_URI__;
+        $ps['endpoints'] = [
+            'orders' => $this->context->link->getModuleLink('miguel', 'api', ['resource' => 'orders'], true),
+            'products' => $this->context->link->getModuleLink('miguel', 'api', ['resource' => 'products'], true),
+            'orderStateCallback' => $this->context->link->getModuleLink('miguel', 'api', ['resource' => 'order-state-callback'], true),
+        ];
+
+        return $ps;
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `vendor/bin/phpunit -c tests/Unit/phpunit.xml --filter PrestashopDetailsTest`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add miguel.php tests/Unit/PrestashopDetailsTest.php
+git commit -m "feat: report front-controller endpoint URLs on connect"
+```
+
+---
+
+## Task 7: Version bump, changelog, packaging
+
+**Files:**
+- Modify: `miguel.php` (`$this->version` near line 53)
+- Modify: `CHANGELOG.md`
+- Modify: `.github/scripts/build-zip.sh` (exclude `docs/` from the shipped zip)
+
+**Interfaces:** none.
+
+- [ ] **Step 1: Bump the module version**
+
+In `miguel.php`, change:
+
+```php
+        $this->version = '1.2.3';
+```
+
+to:
+
+```php
+        $this->version = '1.3.0';
+```
+
+- [ ] **Step 2: Add the changelog entry**
+
+At the top of `CHANGELOG.md`, immediately under the `# CHANGELOG` heading, insert:
+
+```markdown
+## v1.3.0
+
+Added:
+
+- Native PrestaShop API endpoint via a module front controller (`index.php?fc=module&module=miguel&controller=api&resource=…`), routed through the shop's `index.php` so it is no longer blocked by Cloudflare/Apache rules against direct PHP access in `/modules/`.
+- The module now reports its endpoint URLs to Miguel on connect (`endpoints` in the connect payload).
+- Fallback API-token transport via the `X-Miguel-Token` header for environments that strip `Authorization`.
+
+Changed:
+
+- The legacy `orders.php`, `products.php`, and `order-state-callback.php` scripts now delegate to the shared dispatcher and are deprecated (kept for backward compatibility).
+```
+
+- [ ] **Step 3: Exclude docs from the shipped zip**
+
+In `.github/scripts/build-zip.sh`, add `docs` to the `ignore` list so specs/plans are not packaged. Change:
+
+```bash
+ignore=".git .github .idea .vscode .gitignore .php-cs-fixer.dist.php .php-cs-fixer.cache composer.* tests run doc vendor vendor2 docker-compose.yml docker-compose.test.yml Makefile *.zip"
+```
+
+to (add `docs` after `doc`):
+
+```bash
+ignore=".git .github .idea .vscode .gitignore .php-cs-fixer.dist.php .php-cs-fixer.cache composer.* tests run doc docs vendor vendor2 docker-compose.yml docker-compose.test.yml Makefile *.zip"
+```
+
+- [ ] **Step 4: Run the full suite**
+
+Run: `make test`
+Expected: the full PHPUnit suite passes (new tests from Tasks 1–3 and 6 plus the unchanged endpoint regression tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add miguel.php CHANGELOG.md .github/scripts/build-zip.sh
+git commit -m "chore: bump to 1.3.0, changelog, exclude docs from zip"
+```
+
+---
+
+## Coordinated backend change (out of scope, tracked here)
+
+For the new routing to be used in production, the Miguel backend (separate repository) must:
+
+1. Prefer the `endpoints` map from the connect payload when present.
+2. Fall back to the legacy `/modules/miguel/<script>.php` paths for installs that do not report `endpoints`.
+
+Until the backend ships this, the legacy scripts remain the active path. No PrestaShop-module code depends on the backend change, so this plan is independently shippable.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Dispatcher front controller (spec §1) → Task 5.
+- Shared dispatcher (spec §2) → Task 3.
+- Bearer + `X-Miguel-Token` fallback (spec §3) → Task 2.
+- Report endpoint URLs on connect (spec §4) → Task 6.
+- Legacy scripts → thin shims (spec §5) → Task 4.
+- Testing (spec §6) → Tasks 1–3, 6 (unit) + Task 5 (smoke) + Task 4 (regression).
+- Versioning (spec §7) → Task 7.
+- New error types `resourceNotFound`/`methodNotAllowed` (spec §2) → Task 1.
+- Response contract HTTP 200 + JSON envelope → preserved by dispatcher returning `MiguelApiResponse`; scripts/controller `echo json_encode(...)` with no status code changes.
+- Backend coordination note (spec "out of scope") → captured in the "Coordinated backend change" section.
+
+**Type consistency:** `dispatch(string $resource, string $method, array $get, string $rawBody): MiguelApiResponse` used identically in Tasks 3, 4, 5. `getCustomTokenHeader()` defined in Task 2 and referenced nowhere else. Error factories `resourceNotFound`/`methodNotAllowed` defined in Task 1, consumed in Task 3. `endpoints` keys `orders`/`products`/`orderStateCallback` consistent between Task 6 code and test.
+
+**Placeholder scan:** no TBD/TODO; every code step shows complete code; every test step shows the assertion and the exact run command with expected result.

--- a/docs/superpowers/plans/2026-07-18-module-front-controller-api.md
+++ b/docs/superpowers/plans/2026-07-18-module-front-controller-api.md
@@ -16,7 +16,7 @@
 - New utility classes live in the `Miguel\Utils` namespace (matches existing `src/utils/*`).
 - Response contract is **HTTP 200 + JSON envelope** for every outcome (success and error). Never emit real HTTP error status codes — the backend parser depends on the envelope.
 - Resource identifiers are exactly: `orders`, `products`, `order-state-callback`. These strings are hardcoded on the backend — do not rename.
-- Test environment: DB-backed tests extend `Tests\Unit\Utility\DatabaseTestCase` and require the dockerized test stack. Bring it up and run the full suite with `make test`. Run a single test with `vendor/bin/phpunit -c tests/Unit/phpunit.xml --filter <TestName>` once the environment (MySQL + PrestaShop in `vendor2/PrestaShop`) is available.
+- Test environment: tests run **entirely in Docker** — there is no host PHP. Run the full suite with `make test-docker`; run a single test with `make test-docker ARGS="--filter <TestName>"`. (The plan's older `vendor/bin/phpunit -c tests/Unit/phpunit.xml --filter <TestName>` invocations map to `make test-docker ARGS="--filter <TestName>"`.) The first run clones + installs PrestaShop into cached volumes (slow); subsequent runs are ~30–60s and reset `test_prestashop` for isolation. DB-backed tests extend `Tests\Unit\Utility\DatabaseTestCase`.
 - Bump version to `1.3.0` (done in the final task) — do not touch `$this->version` in intermediate tasks.
 
 ---

--- a/docs/superpowers/specs/2026-07-18-module-front-controller-api-design.md
+++ b/docs/superpowers/specs/2026-07-18-module-front-controller-api-design.md
@@ -1,0 +1,172 @@
+# PrestaShop-native API endpoints via a module front controller
+
+**Date:** 2026-07-18
+**Status:** Approved (design)
+**Module:** miguel (PrestaShop)
+
+## Problem
+
+The module exposes three public API endpoints for the Miguel backend as
+**direct-access PHP scripts** in the module root:
+
+- `order-state-callback.php` — POST; Miguel changes PrestaShop order states.
+- `orders.php` — GET; returns orders updated since a timestamp.
+- `products.php` — GET; returns the product catalog.
+
+They are reached at URLs like `https://shop.com/modules/miguel/orders.php` and kept
+reachable by an `.htaccess` allowlist that re-permits exactly those three files after
+denying all other `.php` in the module directory.
+
+This is the classic "executable PHP inside `/modules/`" pattern that Cloudflare WAF
+rules and hardened Apache / hosting configurations routinely block. The module's own
+`.htaccess` allowlist cannot override a Cloudflare managed rule or a server-level
+`<Directory>` deny, so the endpoints intermittently become **inaccessible**.
+
+## Goal
+
+Serve the same three endpoints through PrestaShop's native routing so requests go
+through the shop's root `index.php` dispatcher — the one entry point that cannot be
+blocked without taking down the whole shop — while keeping existing installs working
+during the transition.
+
+## Approaches considered
+
+1. **Module front controller** — *chosen.* PrestaShop's equivalent of WordPress
+   `register_rest_route`. A registered controller class reached through root
+   `index.php`. Sidesteps the "PHP in modules is forbidden" problem entirely.
+2. **PrestaShop Webservice API (`/api/`)** — rejected. Heavyweight, models resources
+   its own way, uses WS keys rather than the existing bearer token, does not fit the
+   custom callback logic, and `/api/` is itself frequently blocked.
+3. **Infra-only allowlisting (Cloudflare/Apache)** — rejected. The current approach;
+   fragile, per-customer, and not owned by the module.
+
+## Key constraint
+
+The Miguel backend currently **hardcodes the endpoint paths**: on connect the module
+sends `baseUrl` + `baseUri` (see `getPrestashopDetails()`), and the backend appends
+`/modules/miguel/orders.php` etc. itself. Therefore the new front-controller URLs will
+not be called until the backend also changes. The chosen migration makes the module
+**authoritative about its own routing** by reporting its endpoint URLs on connect, so
+future routing changes never again require a backend change.
+
+## Design
+
+### 1. Dispatcher front controller
+
+**File:** `controllers/front/api.php` → `class MiguelApiModuleFrontController extends ModuleFrontController`
+
+- `public $auth = false;` — no customer login; the bearer token authenticates.
+- `public $ssl = true;` — Miguel always calls over HTTPS.
+- Routes on a `resource` query parameter → `orders` | `products` |
+  `order-state-callback`, enforcing the correct HTTP method per resource
+  (GET for `orders`/`products`, POST for `order-state-callback`).
+- Overrides `initContent()` to emit **raw JSON and `exit`** — no Smarty/theme
+  rendering, mirroring the legacy scripts.
+- Overrides `displayMaintenancePage()` to a no-op so the API keeps working while the
+  shop is in maintenance mode (a raw script ignores maintenance; a front controller
+  normally would not — this preserves today's behavior).
+
+**New URLs** (both produced by `getModuleLink`, both work):
+
+- `https://shop.com/index.php?fc=module&module=miguel&controller=api&resource=orders`
+  (always works, no URL rewriting required)
+- `https://shop.com/module/miguel/api?resource=orders` (pretty form, when rewriting is on)
+
+No `hookModuleRoutes` / custom route registration is needed — the
+`index.php?fc=module&module=miguel&controller=api` form works out of the box.
+
+### 2. Shared dispatcher (extracted, testable)
+
+**File:** `src/utils/miguel-api-dispatcher.php` → `class MiguelApiDispatcher`
+
+```php
+dispatch(string $resource, string $method, array $get, string $rawBody): MiguelApiResponse
+```
+
+Responsibilities:
+
+1. Validate access via `Miguel::validateApiAccess()`.
+2. Enforce the HTTP method for the resource.
+3. Route to the existing module methods: `getUpdatedOrders($updated_since)`,
+   `getAllProducts()`, `setOrderStates($data)`.
+4. Return a `MiguelApiResponse` — **never echoes**.
+
+Both the front controller and the legacy scripts call this, giving one source of truth
+for routing/validation that is unit-testable without output buffering.
+
+**New error types** in `MiguelApiError`:
+
+- `resourceNotFound` — unknown/absent `resource`.
+- `methodNotAllowed` — wrong HTTP method for the resource.
+
+### 3. Auth: Bearer + `X-Miguel-Token` fallback
+
+`getBearerToken()` gains a fallback: when the `Authorization` bearer is absent or
+stripped by a proxy, read the same token from the `X-Miguel-Token` header
+(`$_SERVER['HTTP_X_MIGUEL_TOKEN']`, using the existing `getallheaders()` polyfill).
+`validateApiAccess()` is otherwise unchanged.
+
+The response contract stays **HTTP 200 + JSON envelope** (never real HTTP error status
+codes) so the existing backend parser is unaffected.
+
+### 4. Report endpoint URLs on connect
+
+`getPrestashopDetails()` adds an `endpoints` map built with
+`getModuleLink('miguel', 'api', ['resource' => …], true)`:
+
+```json
+"endpoints": {
+  "orders": "https://shop/index.php?fc=module&module=miguel&controller=api&resource=orders",
+  "products": "https://shop/index.php?fc=module&module=miguel&controller=api&resource=products",
+  "orderStateCallback": "https://shop/index.php?fc=module&module=miguel&controller=api&resource=order-state-callback"
+}
+```
+
+`baseUrl` / `baseUri` remain for backward compatibility.
+
+**Coordinated backend change (separate repository, out of scope for this module's
+implementation but required for the new routes to be used):** prefer `endpoints` when
+present; fall back to the legacy `/modules/miguel/*.php` paths for installs that do not
+report them.
+
+### 5. Legacy scripts → thin shims (kept)
+
+`orders.php`, `products.php`, and `order-state-callback.php` remain reachable via the
+current `.htaccess` allowlist and are reduced to thin entry points that delegate to
+`MiguelApiDispatcher`. They are marked `@deprecated` and stay for old-backend /
+mid-transition installs, scheduled for removal in a future major version. The
+`.htaccess` allowlist stays for now.
+
+### 6. Testing
+
+- New unit tests for `MiguelApiDispatcher`: resource routing, method enforcement,
+  unknown resource, and `X-Miguel-Token` fallback — direct return-value assertions.
+- Existing `OrdersTest` / `ProductsTest` / `OrderStateCallbackTest` keep passing
+  unchanged (the legacy scripts still exist and still emit the same output).
+- A controller-level smoke test hitting
+  `index.php?fc=module&module=miguel&controller=api` against the dockerized PrestaShop,
+  covering PS 1.7 / 8 / 9.
+
+### 7. Versioning
+
+Minor feature → bump `1.2.3` → **`1.3.0`**; update `CHANGELOG.md` and the `$this->version`
+constant in `miguel.php`.
+
+## Decisions locked
+
+- **Controller shape:** single dispatcher controller (not three separate controllers),
+  routing on `resource` — closest to `register_rest_route` with a router.
+- **Resource keys:** exactly `orders`, `products`, `order-state-callback` (the backend
+  will hardcode these strings).
+- **Migration/compatibility:** report URLs on connect **and** keep the legacy scripts as
+  fallback shims during a deprecation window (no flag day).
+- **Auth transport:** `Authorization: Bearer` primary + `X-Miguel-Token` custom-header
+  fallback.
+- **Response contract:** HTTP 200 + JSON envelope preserved (no real status codes).
+
+## Out of scope
+
+- The Miguel backend change to prefer reported `endpoints` (separate repository;
+  noted here as a required dependency).
+- Removing the legacy scripts and the `.htaccess` allowlist (future major version).
+- Pretty-URL route customization via `hookModuleRoutes`.

--- a/miguel.php
+++ b/miguel.php
@@ -17,6 +17,7 @@ require_once 'src/utils/miguel-api-response.php';
 require_once 'src/utils/miguel-api-create-order-item.php';
 require_once 'src/utils/miguel-api-create-order-request.php';
 require_once 'src/utils/miguel-api-error.php';
+require_once 'src/utils/miguel-api-dispatcher.php';
 require_once 'src/utils/polyfill-getallheaders.php';
 
 use Miguel\Utils\MiguelApiCreateOrderRequest;

--- a/miguel.php
+++ b/miguel.php
@@ -51,7 +51,7 @@ class Miguel extends Module
     {
         $this->name = 'miguel';
         $this->tab = 'administration';
-        $this->version = '1.2.3';
+        $this->version = '1.3.0';
         $this->author = 'Servantes';
         $this->need_instance = 1;
         $this->bootstrap = true;

--- a/miguel.php
+++ b/miguel.php
@@ -837,6 +837,37 @@ class Miguel extends Module
             }
         }
 
+        // Fallback: some proxies strip the Authorization header. Accept the same
+        // token via the X-Miguel-Token custom header, which is stripped far less often.
+        $customToken = $this->getCustomTokenHeader();
+        if (!empty($customToken)) {
+            return $customToken;
+        }
+
+        return false;
+    }
+
+    /**
+     * Reads the API token from the X-Miguel-Token custom header. Used as a fallback
+     * when a proxy strips the Authorization header.
+     *
+     * @return string|false
+     */
+    public function getCustomTokenHeader()
+    {
+        if (isset($_SERVER['HTTP_X_MIGUEL_TOKEN'])) {
+            return trim($_SERVER['HTTP_X_MIGUEL_TOKEN']);
+        }
+
+        $headers = getallheaders();
+        if (is_array($headers)) {
+            foreach ($headers as $key => $value) {
+                if (strtolower($key) === 'x-miguel-token') {
+                    return trim($value);
+                }
+            }
+        }
+
         return false;
     }
 

--- a/miguel.php
+++ b/miguel.php
@@ -614,6 +614,11 @@ class Miguel extends Module
         $ps['moduleVersion'] = $this->version;
         $ps['baseUrl'] = Tools::getShopDomainSsl(true);
         $ps['baseUri'] = __PS_BASE_URI__;
+        $ps['endpoints'] = [
+            'orders' => $this->context->link->getModuleLink('miguel', 'api', ['resource' => 'orders'], true),
+            'products' => $this->context->link->getModuleLink('miguel', 'api', ['resource' => 'products'], true),
+            'orderStateCallback' => $this->context->link->getModuleLink('miguel', 'api', ['resource' => 'order-state-callback'], true),
+        ];
 
         return $ps;
     }

--- a/order-state-callback.php
+++ b/order-state-callback.php
@@ -20,13 +20,18 @@ tato stránka slouží jako API, pro automatickou změnu stavů v PS
 require_once __DIR__ . '/../../config/config.inc.php';
 require_once __DIR__ . '/miguel.php';
 
-use Miguel\Utils\MiguelApiError;
-use Miguel\Utils\MiguelApiResponse;
+use Miguel\Utils\MiguelApiDispatcher;
 
 // required thing for PrestaShop validator (needs to be after config.inc.php)
 if (!defined('_PS_VERSION_')) {
     exit;
 }
+
+/*
+ * @deprecated Use the module front controller instead:
+ * index.php?fc=module&module=miguel&controller=api&resource=order-state-callback
+ * Kept for backward compatibility; scheduled for removal in a future major version.
+ */
 
 $module = Miguel::createInstance();
 $context = Context::getContext();
@@ -35,19 +40,7 @@ $context->controller = new FrontController();
 header('Content-Type: application/json; charset=UTF-8');
 header('User-Agent: ' . $module->getUserAgent());
 
-$valid = $module->validateApiAccess();
-if ($valid !== true) {
-    echo json_encode($valid, JSON_PRETTY_PRINT);
-} else {
-    $json = $module->readFileContent('php://input');
-    $data = json_decode($json, true);
-    if (null === $data) {
-        $output = MiguelApiResponse::error(MiguelApiError::invalidPayload('payload is required'));
-    } elseif (false == array_key_exists('code', $data)) {
-        $output = MiguelApiResponse::error(MiguelApiError::invalidPayload('code not set'));
-    } else {
-        $output = MiguelApiResponse::success($module->setOrderStates($data), 'result');
-    }
+$dispatcher = new MiguelApiDispatcher($module);
+$output = $dispatcher->dispatch('order-state-callback', 'POST', $_GET, $module->readFileContent('php://input'));
 
-    echo json_encode($output);
-}
+echo json_encode($output);

--- a/orders.php
+++ b/orders.php
@@ -21,13 +21,19 @@ je nutné se ověřit pomocí tokenu
 require_once __DIR__ . '/../../config/config.inc.php';
 require_once __DIR__ . '/miguel.php';
 
-use Miguel\Utils\MiguelApiError;
-use Miguel\Utils\MiguelApiResponse;
+use Miguel\Utils\MiguelApiDispatcher;
 
 // required thing for PrestaShop validator (needs to be after config.inc.php)
 if (!defined('_PS_VERSION_')) {
     exit;
 }
+
+/*
+ * @deprecated Use the module front controller instead:
+ * index.php?fc=module&module=miguel&controller=api&resource=orders
+ * Kept for backward compatibility with older backend behavior; scheduled for
+ * removal in a future major version.
+ */
 
 $module = Miguel::createInstance();
 $context = Context::getContext();
@@ -36,15 +42,7 @@ $context->controller = new FrontController();
 header('Content-Type: application/json; charset=UTF-8');
 header('User-Agent: ' . $module->getUserAgent());
 
-$valid = $module->validateApiAccess();
-if ($valid !== true) {
-    echo json_encode($valid, JSON_PRETTY_PRINT);
-} else {
-    if (false == Tools::getIsset('updated_since')) {
-        $output = MiguelApiResponse::error(MiguelApiError::argumentNotSet('updated_since'));
-    } else {
-        $output = MiguelApiResponse::success($module->getUpdatedOrders(Tools::getValue('updated_since')), 'orders');
-    }
+$dispatcher = new MiguelApiDispatcher($module);
+$output = $dispatcher->dispatch('orders', 'GET', $_GET, '');
 
-    echo json_encode($output, JSON_PRETTY_PRINT);
-}
+echo json_encode($output, JSON_PRETTY_PRINT);

--- a/products.php
+++ b/products.php
@@ -21,12 +21,18 @@ je nutné se ověřit pomocí tokenu
 require_once __DIR__ . '/../../config/config.inc.php';
 require_once __DIR__ . '/miguel.php';
 
-use Miguel\Utils\MiguelApiResponse;
+use Miguel\Utils\MiguelApiDispatcher;
 
 // required thing for PrestaShop validator (needs to be after config.inc.php)
 if (!defined('_PS_VERSION_')) {
     exit;
 }
+
+/*
+ * @deprecated Use the module front controller instead:
+ * index.php?fc=module&module=miguel&controller=api&resource=products
+ * Kept for backward compatibility; scheduled for removal in a future major version.
+ */
 
 $module = Miguel::createInstance();
 $context = Context::getContext();
@@ -35,10 +41,7 @@ $context->controller = new FrontController();
 header('Content-Type: application/json; charset=UTF-8');
 header('User-Agent: ' . $module->getUserAgent());
 
-$valid = $module->validateApiAccess();
-if ($valid !== true) {
-    echo json_encode($valid, JSON_PRETTY_PRINT);
-} else {
-    $output = MiguelApiResponse::success($module->getAllProducts(), 'products');
-    echo json_encode($output, JSON_PRETTY_PRINT);
-}
+$dispatcher = new MiguelApiDispatcher($module);
+$output = $dispatcher->dispatch('products', 'GET', $_GET, '');
+
+echo json_encode($output, JSON_PRETTY_PRINT);

--- a/src/utils/miguel-api-dispatcher.php
+++ b/src/utils/miguel-api-dispatcher.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * 2024 Servantes
+ *
+ * This file is licenced under the Software License Agreement.
+ * With the purchase or the installation of the software in your application
+ * you accept the licence agreement.
+ *
+ * You must not modify, adapt or create derivative works of this source code
+ *
+ *  @author Roman Kříž <roman.kriz@servantes.cz>
+ *  @copyright  2022 - 2024 Servantes
+ *  @license LICENSE.txt
+ */
+
+namespace Miguel\Utils;
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+/**
+ * Central routing/validation for the Miguel public API. Shared by the module
+ * front controller and the legacy direct-access scripts. Never echoes: it
+ * returns a MiguelApiResponse that the caller serializes.
+ */
+class MiguelApiDispatcher
+{
+    /**
+     * @var \Miguel
+     */
+    private $module;
+
+    public function __construct(\Miguel $module)
+    {
+        $this->module = $module;
+    }
+
+    /**
+     * @param string $resource one of: orders, products, order-state-callback
+     * @param string $method   HTTP method (GET/POST)
+     * @param array $get       query parameters
+     * @param string $rawBody  raw request body (for POST resources)
+     *
+     * @return MiguelApiResponse
+     */
+    public function dispatch($resource, $method, array $get, $rawBody)
+    {
+        $valid = $this->module->validateApiAccess();
+        if ($valid !== true) {
+            return $valid;
+        }
+
+        switch ($resource) {
+            case 'orders':
+                if ($method !== 'GET') {
+                    return MiguelApiResponse::error(MiguelApiError::methodNotAllowed($method));
+                }
+                if (!isset($get['updated_since'])) {
+                    return MiguelApiResponse::error(MiguelApiError::argumentNotSet('updated_since'));
+                }
+
+                return MiguelApiResponse::success($this->module->getUpdatedOrders($get['updated_since']), 'orders');
+
+            case 'products':
+                if ($method !== 'GET') {
+                    return MiguelApiResponse::error(MiguelApiError::methodNotAllowed($method));
+                }
+
+                return MiguelApiResponse::success($this->module->getAllProducts(), 'products');
+
+            case 'order-state-callback':
+                if ($method !== 'POST') {
+                    return MiguelApiResponse::error(MiguelApiError::methodNotAllowed($method));
+                }
+                $data = json_decode($rawBody, true);
+                if (null === $data) {
+                    return MiguelApiResponse::error(MiguelApiError::invalidPayload('payload is required'));
+                }
+                if (!array_key_exists('code', $data)) {
+                    return MiguelApiResponse::error(MiguelApiError::invalidPayload('code not set'));
+                }
+
+                return MiguelApiResponse::success($this->module->setOrderStates($data), 'result');
+
+            default:
+                return MiguelApiResponse::error(MiguelApiError::resourceNotFound((string) $resource));
+        }
+    }
+}

--- a/src/utils/miguel-api-dispatcher.php
+++ b/src/utils/miguel-api-dispatcher.php
@@ -38,9 +38,9 @@ class MiguelApiDispatcher
 
     /**
      * @param string $resource one of: orders, products, order-state-callback
-     * @param string $method   HTTP method (GET/POST)
-     * @param array $get       query parameters
-     * @param string $rawBody  raw request body (for POST resources)
+     * @param string $method HTTP method (GET/POST)
+     * @param array $get query parameters
+     * @param string $rawBody raw request body (for POST resources)
      *
      * @return MiguelApiResponse
      */

--- a/src/utils/miguel-api-dispatcher.php
+++ b/src/utils/miguel-api-dispatcher.php
@@ -44,7 +44,7 @@ class MiguelApiDispatcher
      *
      * @return MiguelApiResponse
      */
-    public function dispatch($resource, $method, array $get, $rawBody)
+    public function dispatch(string $resource, string $method, array $get, string $rawBody): MiguelApiResponse
     {
         $valid = $this->module->validateApiAccess();
         if ($valid !== true) {
@@ -77,7 +77,7 @@ class MiguelApiDispatcher
                 if (null === $data) {
                     return MiguelApiResponse::error(MiguelApiError::invalidPayload('payload is required'));
                 }
-                if (!array_key_exists('code', $data)) {
+                if (!is_array($data) || !array_key_exists('code', $data)) {
                     return MiguelApiResponse::error(MiguelApiError::invalidPayload('code not set'));
                 }
 

--- a/src/utils/miguel-api-error.php
+++ b/src/utils/miguel-api-error.php
@@ -111,6 +111,16 @@ class MiguelApiError implements \JsonSerializable
         return new self('payload.invalid', "Invalid payload: $message");
     }
 
+    public static function resourceNotFound($resource): MiguelApiError
+    {
+        return new self('resource.not_found', "Resource $resource not found");
+    }
+
+    public static function methodNotAllowed($method): MiguelApiError
+    {
+        return new self('method.not_allowed', "Method $method not allowed");
+    }
+
     public static function unknownError(): MiguelApiError
     {
         return new self('unknown.error', 'Unknown error');

--- a/tests/Unit/ApiDispatcherTest.php
+++ b/tests/Unit/ApiDispatcherTest.php
@@ -79,4 +79,26 @@ class ApiDispatcherTest extends DatabaseTestCase
         $this->assertSame('products', $response->getDataKey());
         $this->assertIsArray($response->getData());
     }
+
+    public function testOrderStateCallbackWithEmptyBodyReturnsPayloadInvalid()
+    {
+        $_SERVER['Authorization'] = 'Bearer 1234';
+
+        $response = $this->dispatcher()->dispatch('order-state-callback', 'POST', [], '');
+
+        $this->assertFalse($response->getResult());
+        $this->assertSame('payload.invalid', $response->getData()->getCode());
+        $this->assertSame('Invalid payload: payload is required', $response->getData()->getMessage());
+    }
+
+    public function testOrderStateCallbackWithoutCodeReturnsPayloadInvalid()
+    {
+        $_SERVER['Authorization'] = 'Bearer 1234';
+
+        $response = $this->dispatcher()->dispatch('order-state-callback', 'POST', [], json_encode(['miguel_state' => 'x']));
+
+        $this->assertFalse($response->getResult());
+        $this->assertSame('payload.invalid', $response->getData()->getCode());
+        $this->assertSame('Invalid payload: code not set', $response->getData()->getMessage());
+    }
 }

--- a/tests/Unit/ApiDispatcherTest.php
+++ b/tests/Unit/ApiDispatcherTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Tests\Unit;
+
+use Miguel;
+use Miguel\Utils\MiguelApiDispatcher;
+use Miguel\Utils\MiguelSettings;
+use Tests\Unit\Utility\DatabaseTestCase;
+
+class ApiDispatcherTest extends DatabaseTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        unset($_SERVER['Authorization'], $_SERVER['HTTP_AUTHORIZATION'], $_SERVER['HTTP_X_MIGUEL_TOKEN']);
+
+        MiguelSettings::setEnabled(true);
+        MiguelSettings::save(MiguelSettings::API_TOKEN_PRODUCTION_KEY, '1234');
+    }
+
+    protected function tearDown(): void
+    {
+        unset($_SERVER['Authorization'], $_SERVER['HTTP_AUTHORIZATION'], $_SERVER['HTTP_X_MIGUEL_TOKEN']);
+        parent::tearDown();
+    }
+
+    private function dispatcher(): MiguelApiDispatcher
+    {
+        return new MiguelApiDispatcher(new Miguel());
+    }
+
+    public function testUnknownResourceReturnsResourceNotFound()
+    {
+        $_SERVER['Authorization'] = 'Bearer 1234';
+
+        $response = $this->dispatcher()->dispatch('widgets', 'GET', [], '');
+
+        $this->assertFalse($response->getResult());
+        $this->assertSame('resource.not_found', $response->getData()->getCode());
+    }
+
+    public function testWrongMethodReturnsMethodNotAllowed()
+    {
+        $_SERVER['Authorization'] = 'Bearer 1234';
+
+        $response = $this->dispatcher()->dispatch('order-state-callback', 'GET', [], '');
+
+        $this->assertFalse($response->getResult());
+        $this->assertSame('method.not_allowed', $response->getData()->getCode());
+    }
+
+    public function testOrdersWithoutUpdatedSinceReturnsArgumentNotSet()
+    {
+        $_SERVER['Authorization'] = 'Bearer 1234';
+
+        $response = $this->dispatcher()->dispatch('orders', 'GET', [], '');
+
+        $this->assertFalse($response->getResult());
+        $this->assertSame('argument.not_set', $response->getData()->getCode());
+    }
+
+    public function testInvalidTokenReturnsApiKeyInvalid()
+    {
+        $_SERVER['Authorization'] = 'Bearer wrong';
+
+        $response = $this->dispatcher()->dispatch('products', 'GET', [], '');
+
+        $this->assertFalse($response->getResult());
+        $this->assertSame('api_key.invalid', $response->getData()->getCode());
+    }
+
+    public function testProductsSucceedWithCustomHeaderToken()
+    {
+        $_SERVER['HTTP_X_MIGUEL_TOKEN'] = '1234';
+
+        $response = $this->dispatcher()->dispatch('products', 'GET', [], '');
+
+        $this->assertTrue($response->getResult());
+        $this->assertSame('products', $response->getDataKey());
+        $this->assertIsArray($response->getData());
+    }
+}

--- a/tests/Unit/ApiErrorTest.php
+++ b/tests/Unit/ApiErrorTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Tests\Unit;
+
+use Miguel\Utils\MiguelApiError;
+use PHPUnit\Framework\TestCase;
+
+class ApiErrorTest extends TestCase
+{
+    public function testResourceNotFound()
+    {
+        $error = MiguelApiError::resourceNotFound('widgets');
+
+        $this->assertSame('resource.not_found', $error->getCode());
+        $this->assertSame('Resource widgets not found', $error->getMessage());
+    }
+
+    public function testMethodNotAllowed()
+    {
+        $error = MiguelApiError::methodNotAllowed('DELETE');
+
+        $this->assertSame('method.not_allowed', $error->getCode());
+        $this->assertSame('Method DELETE not allowed', $error->getMessage());
+    }
+}

--- a/tests/Unit/BearerTokenTest.php
+++ b/tests/Unit/BearerTokenTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Tests\Unit;
+
+use Miguel;
+use PHPUnit\Framework\TestCase;
+
+class BearerTokenTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        unset($_SERVER['Authorization'], $_SERVER['HTTP_AUTHORIZATION'], $_SERVER['HTTP_X_MIGUEL_TOKEN']);
+    }
+
+    protected function tearDown(): void
+    {
+        unset($_SERVER['Authorization'], $_SERVER['HTTP_AUTHORIZATION'], $_SERVER['HTTP_X_MIGUEL_TOKEN']);
+        parent::tearDown();
+    }
+
+    public function testReadsBearerFromAuthorizationHeader()
+    {
+        $_SERVER['Authorization'] = 'Bearer abc123';
+
+        $module = new Miguel();
+
+        $this->assertSame('abc123', $module->getBearerToken());
+    }
+
+    public function testFallsBackToCustomHeader()
+    {
+        $_SERVER['HTTP_X_MIGUEL_TOKEN'] = 'abc123';
+
+        $module = new Miguel();
+
+        $this->assertSame('abc123', $module->getBearerToken());
+    }
+
+    public function testReturnsFalseWhenNoToken()
+    {
+        $module = new Miguel();
+
+        $this->assertFalse($module->getBearerToken());
+    }
+}

--- a/tests/Unit/PrestashopDetailsTest.php
+++ b/tests/Unit/PrestashopDetailsTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * 2024 Servantes
+ *
+ * This file is licenced under the Software License Agreement.
+ * With the purchase or the installation of the software in your application
+ * you accept the licence agreement.
+ *
+ * You must not modify, adapt or create derivative works of this source code
+ *
+ *  @author Roman Kříž <roman.kriz@servantes.cz>
+ *  @copyright  2022 - 2024 Servantes
+ *  @license LICENSE.txt
+ */
+
+namespace Tests\Unit;
+
+use Miguel;
+use Tests\Unit\Utility\DatabaseTestCase;
+
+class PrestashopDetailsTest extends DatabaseTestCase
+{
+    public function testIncludesEndpointUrls()
+    {
+        $module = new Miguel();
+
+        $details = $module->getPrestashopDetails();
+
+        $this->assertArrayHasKey('endpoints', $details);
+        $this->assertArrayHasKey('orders', $details['endpoints']);
+        $this->assertArrayHasKey('products', $details['endpoints']);
+        $this->assertArrayHasKey('orderStateCallback', $details['endpoints']);
+
+        $this->assertStringContainsString('resource=orders', $details['endpoints']['orders']);
+        $this->assertStringContainsString('resource=products', $details['endpoints']['products']);
+        $this->assertStringContainsString('resource=order-state-callback', $details['endpoints']['orderStateCallback']);
+    }
+
+    public function testKeepsLegacyBaseFields()
+    {
+        $module = new Miguel();
+
+        $details = $module->getPrestashopDetails();
+
+        $this->assertArrayHasKey('baseUrl', $details);
+        $this->assertArrayHasKey('baseUri', $details);
+        $this->assertArrayHasKey('moduleVersion', $details);
+    }
+}


### PR DESCRIPTION
## Summary

Migrates the three public API endpoints Miguel calls (`orders.php`, `products.php`, `order-state-callback.php`) from **direct-access PHP scripts** in the module folder to a **native PrestaShop module front controller** routed through the shop's `index.php`. This is the PrestaShop equivalent of WordPress's `register_rest_route`.

**Why:** direct `.php` files inside `/modules/` are a classic target for Cloudflare WAF rules and hardened Apache configs, so the endpoints intermittently become unreachable. Routing through `index.php` (the entry point that can't be blocked without taking down the whole shop) removes that failure mode. The legacy scripts stay as thin deprecated shims for a no-flag-day rollout.

Design/plan: `docs/superpowers/specs/2026-07-18-module-front-controller-api-design.md`, `docs/superpowers/plans/2026-07-18-module-front-controller-api.md`.

## What changed

- **`src/utils/miguel-api-dispatcher.php`** (new) — `MiguelApiDispatcher::dispatch(string $resource, string $method, array $get, string $rawBody): MiguelApiResponse`. One source of truth: validate access → enforce HTTP method → route to the existing module methods → return a `MiguelApiResponse` (never echoes).
- **`controllers/front/api.php`** (new) — `MiguelApiModuleFrontController`. Thin adapter: gathers request inputs, calls the dispatcher, emits **pure JSON** (clears output buffers, no theme render), and stays reachable during maintenance/geolocation restriction. Reached at `index.php?fc=module&module=miguel&controller=api&resource=<orders|products|order-state-callback>`.
- **`orders.php` / `products.php` / `order-state-callback.php`** — reduced to thin shims delegating to the dispatcher; marked `@deprecated`.
- **`src/utils/miguel-api-error.php`** — new `resourceNotFound` / `methodNotAllowed` errors.
- **`miguel.php`** — `X-Miguel-Token` header fallback in `getBearerToken()` (for proxies that strip `Authorization`); `getPrestashopDetails()` now reports an `endpoints` map on connect; version bumped **1.2.3 → 1.3.0**.
- **Response contract preserved:** HTTP 200 + JSON envelope for every outcome (the backend parser depends on it).

## ⚠️ Required backend coordination (separate repo)

The Miguel backend currently **hardcodes** `/modules/miguel/*.php` paths. For the new routing to be used it must: **prefer the `endpoints` map from the connect payload when present, and fall back to the legacy paths** for installs that don't report it. No module code depends on this, so this PR is shippable independently — the legacy scripts remain the active path until the backend switches.

## 🔒 Security note — please review

`controllers/front/api.php` overrides `displayRestrictedCountryPage()` to a no-op, so PrestaShop's **geolocation restriction does not block this endpoint**. Rationale: this is a token-authenticated machine-to-machine API whose access gate is the bearer token (`validateApiAccess()`); geolocation is a *storefront browsing* control that would otherwise 403 Miguel's datacenter IP and defeat the feature. The legacy scripts were never subject to it (they bypass `FrontController`), so this restores parity, and it mirrors the already-present maintenance-mode override. Flagging explicitly for your sign-off.

## Dockerized test harness (`make test-docker`)

Adds a fully containerized PHPUnit setup (like the WooCommerce plugin) so the suite runs with **no host PHP/MySQL**: `Dockerfile.test` (php 7.4 + Composer), `docker-compose.test.yml` (mysql 5.7 + phpunit service, cached volumes), `docker/test-entrypoint.sh` (clones a clean PrestaShop 1.7.8.10 once, installs it, resets `test_prestashop` from the pristine install before every run for isolation, places the module like CI, runs PrestaShop's phpunit). `make test-docker ARGS="--filter X"` to scope.

## Verification

- **Full suite green in Docker: `OK (27 tests, 64 assertions)`**, repeatable/isolated (13 pre-existing + 14 new across `ApiErrorTest`, `BearerTokenTest`, `ApiDispatcherTest`, `PrestashopDetailsTest`).
- Whole-branch review: **0 Critical**; 2 Important (array `resource` → TypeError; geolocation gate) both fixed in `3ef364e`.
- CI will run the full matrix (php-lint 7.1→8.4, cs-fixer, PHPStan, PHPUnit on PS 1.7/8/9).
- **Not yet exercised:** a live HTTP curl of the front-controller URL against an installed shop (the front controller's `initContent()` exits, so it isn't covered by the unit suite; routing was verified statically against PrestaShop core `FrontController::init()`). Recommend a quick `curl` smoke test on a real/staging shop after install as final confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)