### PR TITLE
refactor: resolve Context::getContext() validator warnings

### DIFF
--- a/miguel.php
+++ b/miguel.php
@@ -84,6 +84,22 @@ class Miguel extends Module
         self::$sharedInstance = $instance;
     }
 
+    /**
+     * Public accessor for the module's Context.
+     *
+     * The base module context property is protected, so the procedural
+     * entry-point shims (products.php, orders.php, order-state-callback.php)
+     * cannot read it directly. Exposing it here lets those scripts reuse the
+     * context the module already holds instead of reaching for the global
+     * context singleton.
+     *
+     * @return Context
+     */
+    public function getContext()
+    {
+        return $this->context;
+    }
+
     public function install()
     {
         MiguelSettings::reset();
@@ -626,7 +642,7 @@ class Miguel extends Module
     public function getAllProducts()
     {
         try {
-            $context = Context::getContext();
+            $context = $this->context;
 
             $id_shop = (int) Configuration::get('PS_SHOP_DEFAULT');
             $id_lang = (int) Configuration::get('PS_LANG_DEFAULT');
@@ -641,10 +657,10 @@ class Miguel extends Module
 
             $currencyIso = $context->currency->iso_code;
 
-            if (!isset($context->cart) || !$context->cart->id) {
+            if (empty($context->cart->id)) {
                 $context->cart = new Cart();
             }
-            if (!isset($context->customer) || !$context->customer->id) {
+            if (empty($context->customer->id)) {
                 $context->customer = new Customer();
             }
 

--- a/order-state-callback.php
+++ b/order-state-callback.php
@@ -34,7 +34,7 @@ if (!defined('_PS_VERSION_')) {
  */
 
 $module = Miguel::createInstance();
-$context = Context::getContext();
+$context = $module->getContext();
 $context->controller = new FrontController();
 
 header('Content-Type: application/json; charset=UTF-8');

--- a/orders.php
+++ b/orders.php
@@ -36,7 +36,7 @@ if (!defined('_PS_VERSION_')) {
  */
 
 $module = Miguel::createInstance();
-$context = Context::getContext();
+$context = $module->getContext();
 $context->controller = new FrontController();
 
 header('Content-Type: application/json; charset=UTF-8');

--- a/products.php
+++ b/products.php
@@ -35,7 +35,7 @@ if (!defined('_PS_VERSION_')) {
  */
 
 $module = Miguel::createInstance();
-$context = Context::getContext();
+$context = $module->getContext();
 $context->controller = new FrontController();
 
 header('Content-Type: application/json; charset=UTF-8');

--- a/src/utils/miguel-api-create-order-request.php
+++ b/src/utils/miguel-api-create-order-request.php
@@ -60,7 +60,7 @@ class MiguelApiCreateOrderRequest
 
             if (\Pack::isPack($product_id)) {
                 // Get pack items and add them individually
-                $pack_items = \Pack::getItems($product_id, (int) \Context::getContext()->language->id);
+                $pack_items = \Pack::getItems($product_id, (int) $order->id_lang);
 
                 if (empty($pack_items)) {
                     $product_array = self::createArrayFromSimpleProduct($product);
@@ -77,7 +77,7 @@ class MiguelApiCreateOrderRequest
                 $valid_pack_items = [];
 
                 foreach ($pack_items as $pack_item) {
-                    $pack_product = new \Product($pack_item->id, false, (int) \Context::getContext()->language->id);
+                    $pack_product = new \Product($pack_item->id, false, (int) $order->id_lang);
 
                     if (\Validate::isLoadedObject($pack_product) && !empty($pack_product->reference)) {
                         $individual_price = (float) \Product::getPriceStatic($pack_product->id, false, null, 6, null, false, true, 1, false, $order->id_customer, $order->id_cart);

--- a/tests/Unit/Utility/ContextMocker.php
+++ b/tests/Unit/Utility/ContextMocker.php
@@ -110,7 +110,7 @@ class ContextMocker
         LegacyContext::setInstanceForTesting($context);
         Module::setContextInstanceForTesting($context);
         $context->shop = new Shop((int) Configuration::get('PS_SHOP_DEFAULT'));
-        Shop::setContext(Shop::CONTEXT_SHOP, (int) Context::getContext()->shop->id);
+        Shop::setContext(Shop::CONTEXT_SHOP, (int) $context->shop->id);
         // $context->customer = Phake::mock('Customer');
         // Phake::when($context->customer)->getGroups()->thenReturn(array());
         // $context->cookie   = Phake::mock('Cookie');
@@ -136,7 +136,7 @@ class ContextMocker
     {
         Context::setInstanceForTesting($this->contextBackup);
         LegacyContext::setInstanceForTesting($this->contextBackup);
-        Shop::setContext(Shop::CONTEXT_SHOP, (int) Context::getContext()->shop->id);
+        Shop::setContext(Shop::CONTEXT_SHOP, (int) $this->contextBackup->shop->id);
         Module::setContextInstanceForTesting($this->contextBackup);
     }
 }

--- a/tests/Unit/Utility/EntityCreator.php
+++ b/tests/Unit/Utility/EntityCreator.php
@@ -15,19 +15,11 @@
 
 namespace Tests\Unit\Utility;
 
-use Context;
 use Order;
 use OrderDetail;
 
 class EntityCreator
 {
-    private $context;
-
-    public function __construct()
-    {
-        $this->context = Context::getContext();
-    }
-
     /**
      * Creates a new order (not saved in the database)
      *


### PR DESCRIPTION
## Why

The PrestaShop validator reports several warnings about direct `Context::getContext()` singleton usage (see the [PS 9 Symfony context refactorization](https://devdocs.prestashop-project.org/9/modules/core-updates/9.0/#symfony-context-refactorization) docs).

The module declares `ps_versions_compliancy => ['min' => '1.7', 'max' => '9.99.99']`, so it must keep running on PrestaShop 1.7 / 8 / 9. The PS 9 split-context services (`ShopContext`, `CurrencyContext`, `LanguageContext`, …) only exist in 9.0+ and require Symfony DI — adopting them would break 1.7/8. This PR takes the **portable** route instead: stop calling the global singleton where a better-scoped reference already exists. No new dependencies, no version bump.

## Changes

- **`miguel.php`** — `getAllProducts()` uses the injected `$this->context`; added a public `getContext()` accessor. The base `Module::$context` property is `protected`, so the procedural entry-point shims can't read it directly — the accessor lets them reuse the module's context instead of the singleton.
- **`products.php` / `orders.php` / `order-state-callback.php`** (deprecated shims) — use `$module->getContext()`.
- **`src/utils/miguel-api-create-order-request.php`** — pack-item language now resolves from `$order->id_lang` (the method already receives the `\Order`), which is the correct language for that order's product lines.
- **`tests/Unit/Utility/ContextMocker.php`** — reuse the local `$context` / `$this->contextBackup` instead of re-fetching the singleton; the one legitimate backup call (capturing the live global to restore it) is kept.
- **`tests/Unit/Utility/EntityCreator.php`** — removed an unused `$context` property + constructor (dead code).

The only remaining `Context::getContext()` in the codebase is the intentional backup in `ContextMocker` (test-only, not shipped).

## Note on behavior

One intentional change: pack item names/prices in the order payload now resolve in the **order's** language rather than the ambient global-context language. In the API dispatch path this is more correct.

## Test plan

- PHPUnit in Docker (PrestaShop 1.7.8.10 / PHP 7.4): `OK (27 tests, 64 assertions)` ✅
- `php -l` clean on all changed production files (CI's linter is a syntax check across PHP 7.1–8.4; there is no php-cs-fixer step, and `tests/` is excluded from the fixer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)