### PR TITLE
fix(ci): warm PrestaShop DI container before module install (fixes PS 9.0 flaky install)

### DIFF
--- a/.github/scripts/install-prestashop.sh
+++ b/.github/scripts/install-prestashop.sh
@@ -51,5 +51,21 @@ pushd vendor2/PrestaShop > /dev/null
     # create test db
     composer run-script create-test-db
 
+    # Warm the Symfony DI container before any module is installed.
+    #
+    # On a cache hit the "Download PrestaShop" step is skipped, so the container
+    # is never pre-warmed by the clone/composer/asset build. The first *cold*
+    # container build then happens during `prestashop:module install`, and that
+    # cold build omits module service definitions -- so ps_distributionapiclient's
+    # actionBeforeInstallModule hook (which fires on every module install) dies
+    # with: You have requested a non-existent service
+    # "distributionapiclient.distribution_api" (PrestaShop 9.0).
+    #
+    # A prime build followed by a rebuild yields a complete container that
+    # includes every active module's services. Fresh (cache-miss) runs already
+    # get this for free via the download/build step.
+    php bin/console cache:clear
+    php bin/console cache:clear
+
     mkdir -p modules/miguel
 popd > /dev/null

--- a/.github/workflows/php_tests.yml
+++ b/.github/workflows/php_tests.yml
@@ -199,9 +199,11 @@ jobs:
         uses: actions/cache@v4
         with:
           path: vendor2/PrestaShop
-          # -v2: evict caches poisoned by the previously broken Cleanup step,
-          # which left a compiled DI container in var/cache and broke module
-          # installs on restore (e.g. PrestaShop 9.0 distributionapiclient service).
+          # On a cache hit the Download step is skipped, so PrestaShop's Symfony
+          # container is never pre-warmed; install-prestashop.sh warms it before
+          # module install so module services (e.g. the PrestaShop 9.0
+          # distributionapiclient.distribution_api used by ps_distributionapiclient's
+          # actionBeforeInstallModule hook) are compiled in.
           key: prestashop-${{ matrix.prestashop-version }}-v2
 
       - name: Download PrestaShop


### PR DESCRIPTION
## Problem

The PHPUnit **9.0.3** matrix jobs failed on almost every run during `prestashop:module install miguel`:

```
You have requested a non-existent service "distributionapiclient.distribution_api".
```

## Root cause

Confirmed from CI logs: **fresh (cache-miss) runs pass; every cache-restored run fails**, deterministically.

- On a **cache hit**, the `Download PrestaShop` step is skipped (the dir already exists), so PrestaShop's Symfony DI container is never pre-warmed by the clone/composer/`make assets` build.
- The first **cold** container build then happens during `prestashop:module install`, and that cold build **omits module service definitions**.
- Installing any module fires the core `ps_distributionapiclient` module's `actionBeforeInstallModule` hook, which does `$this->get('distributionapiclient.distribution_api')` → the service isn't in the container → `CoreException`.

A diagnostic run proved that rebuilding the container before module install makes the 9.0.3 job pass on the exact cache that was failing (`debug:container` showed the service missing on the first cold build, present after a rebuild).

## Fix

Warm the container (prime + rebuild) at the end of `install-prestashop.sh`, before any module is installed, so it includes every active module's services. Fresh runs already get this for free via the download/build step. **No cache key bump needed** — it works against the existing cache.

## Verification

CI run on this branch: **9.0.3 jobs were a `Cache hit for: prestashop-9.0.3-v2`** (the previously-failing cache) and **passed**; the full 19-job matrix is green (no regression on 1.7.8 / 8.0 / 8.1 / 8.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)